### PR TITLE
Fix query race condition on gRPC server stream

### DIFF
--- a/api/v1/challenge/query.go
+++ b/api/v1/challenge/query.go
@@ -127,7 +127,7 @@ func (store *Store) QueryChallenge(_ *emptypb.Empty, server ChallengeStore_Query
 				})
 			}
 
-			if err := server.Send(&Challenge{
+			if err := sendMsg(server, &Challenge{
 				Id:        id,
 				Hash:      fschall.Hash,
 				Timeout:   toPBDuration(fschall.Timeout),
@@ -165,4 +165,15 @@ func (store *Store) QueryChallenge(_ *emptypb.Empty, server ChallengeStore_Query
 		return errs.ErrInternalNoSub
 	}
 	return merr // should remain nil as does not depend on user inputs, but makes it future-proof
+}
+
+var (
+	qmx = &sync.Mutex{}
+)
+
+func sendMsg(server ChallengeStore_QueryChallengeServer, ch *Challenge) error {
+	qmx.Lock()
+	defer qmx.Unlock()
+
+	return server.SendMsg(ch)
 }


### PR DESCRIPTION
When dealing with a large amount of queries on rich volume of challenges and instances, the gRPC server stream ran in concurrent access leading to failures in the responses, thus inconsistent results in upstream services.

The solution if fairly simple : pass through a mutex to make sure no parallel access to the server stream :smile: