### PR TITLE
Improve query locks on gRPC server streaming

### DIFF
--- a/api/v1/common/query_server.go
+++ b/api/v1/common/query_server.go
@@ -1,0 +1,32 @@
+package common
+
+import (
+	"sync"
+
+	"google.golang.org/grpc"
+)
+
+// QueryServer is a generic implementation of a synchronous gRPC server.
+// Use it when dealing with a query that streams asynchronously, but gRPC
+// requires it to be else it will crash the stream.
+type QueryServer[T any] struct {
+	srv grpc.ServerStream
+	mx  *sync.Mutex
+}
+
+// NewQueryServer creates a throwable server to stream synchronously to
+// a gRPC stream server.
+func NewQueryServer[T any](server grpc.ServerStream) *QueryServer[T] {
+	return &QueryServer[T]{
+		srv: server,
+		mx:  &sync.Mutex{},
+	}
+}
+
+// SendMsg synchronously when asynchrouneous tasks is possible.
+func (qs *QueryServer[T]) SendMsg(in T) error {
+	qs.mx.Lock()
+	defer qs.mx.Unlock()
+
+	return qs.srv.SendMsg(in)
+}


### PR DESCRIPTION
In #285 I introduced a mecanism to send gRPC stream server data synchronously.
This lock was global, leading to poor performances for no reasons : only 1 lock existed for all queries...

In this PR, I solve this with a generic `QueryServer` for the lifetime of a request, and reusable so future-proof.