### PR TITLE
Improve logs to better understand what is going on

### DIFF
--- a/api/v1/challenge/create.go
+++ b/api/v1/challenge/create.go
@@ -120,6 +120,7 @@ func (store *Store) CreateChallenge(ctx context.Context, req *CreateChallengeReq
 		return nil, errs.ErrInternalNoSub
 	}
 
+	logger.Info(ctx, "challenge created successfully")
 	common.ChallengesUDCounter().Add(ctx, 1)
 
 	chall := &Challenge{

--- a/api/v1/challenge/delete.go
+++ b/api/v1/challenge/delete.go
@@ -98,6 +98,9 @@ func (store *Store) DeleteChallenge(ctx context.Context, req *DeleteChallengeReq
 	}
 
 	// 6. Create "relock" and "work" wait groups for all instances, and for each
+	logger.Info(ctx, "deleting challenge",
+		zap.Int("instances", len(iids)),
+	)
 	relock := &sync.WaitGroup{} // track goroutines that overlocked an identity
 	relock.Add(len(iids))
 	work := &sync.WaitGroup{} // track goroutines that ended dealing with the instances
@@ -201,6 +204,7 @@ func (store *Store) DeleteChallenge(ctx context.Context, req *DeleteChallengeReq
 		return nil, errs.ErrInternalNoSub
 	}
 
+	logger.Info(ctx, "challenge deleted successfully")
 	common.ChallengesUDCounter().Add(ctx, -1)
 
 	return nil, nil

--- a/api/v1/challenge/update.go
+++ b/api/v1/challenge/update.go
@@ -168,6 +168,10 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 	}
 
 	// 7. Create "relock" and "work" wait groups for all instance, and for each
+	logger.Info(ctx, "updating challenge",
+		zap.Int("instances", len(iids)),
+		zap.Bool("update_scenario", updateScenario),
+	)
 	relock := &sync.WaitGroup{}
 	relock.Add(len(iids))
 	work := &sync.WaitGroup{}
@@ -300,6 +304,8 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 		)
 		return nil, errs.ErrInternalNoSub
 	}
+
+	logger.Info(ctx, "challenge updated successfully")
 
 	ists := make([]*instance.Instance, 0, len(iids))
 	for ist := range cist {

--- a/api/v1/instance/create.go
+++ b/api/v1/instance/create.go
@@ -129,7 +129,7 @@ func (man *Manager) CreateInstance(ctx context.Context, req *CreateInstanceReque
 		return nil, errs.ErrInternalNoSub
 	}
 
-	logger.Info(ctx, "deploying challenge scenario")
+	logger.Info(ctx, "creating instance")
 
 	sr, err := stack.Up(ctx)
 	if err != nil {
@@ -163,6 +163,7 @@ func (man *Manager) CreateInstance(ctx context.Context, req *CreateInstanceReque
 		return nil, errs.ErrInternalNoSub
 	}
 
+	logger.Info(ctx, "instance created successfully")
 	common.InstancesUDCounter().Add(ctx, 1)
 
 	// 8. Unlock RW instance

--- a/api/v1/instance/delete.go
+++ b/api/v1/instance/delete.go
@@ -165,6 +165,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 		return nil, errs.ErrInternalNoSub
 	}
 
+	logger.Info(ctx, "deleted instance successfully")
 	common.InstancesUDCounter().Add(ctx, -1)
 
 	// 7. Unlock RW instance

--- a/api/v1/instance/renew.go
+++ b/api/v1/instance/renew.go
@@ -131,6 +131,7 @@ func (man *Manager) RenewInstance(ctx context.Context, req *RenewInstanceRequest
 	fsist.LastRenew = now
 	fsist.Until = common.ComputeUntil(fschall.Until, fschall.Timeout)
 
+	logger.Info(ctx, "renewing instance")
 	if err := fsist.Save(); err != nil {
 		logger.Error(ctx, "exporting instance information to filesystem",
 			zap.Error(err),


### PR DESCRIPTION
This PR solves the problem we observed through the NoBrackets 2024 where logs where insufficient to understand what was going on through production workload.

We had to work around the problem by using OpenTelemetry traces, which is not good (should be used to debug distributed systems, not one system).