### PR TITLE
Add permissions to get/list/watch events through stuck deployments

### DIFF
--- a/deploy/services/parts/chall-manager.go
+++ b/deploy/services/parts/chall-manager.go
@@ -360,6 +360,19 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 				}),
 				Verbs: pulumi.ToStringArray(crudVerbs),
 			},
+			rbacv1.PolicyRuleArgs{
+				ApiGroups: pulumi.ToStringArray([]string{
+					"events.k8s.io",
+				}),
+				Resources: pulumi.ToStringArray([]string{
+					"events",
+				}),
+				Verbs: pulumi.ToStringArray([]string{
+					"get",
+					"list",
+					"watch",
+				}),
+			},
 		},
 	}, opts...)
 	if err != nil {


### PR DESCRIPTION
This PR solves the problem we encountered through the NoBrackets 2024 where a stuck deployment (due to a misconfigured Network Policy) had to timeout because the Pulumi Kubernetes provider could not look for events to understand what was happening.

With additional permissions to look at events, such cases should not occur anymore.