### PR TITLE
Fix API retrieving unexisting resource returning errors

### DIFF
--- a/api/v1/challenge/retrieve.go
+++ b/api/v1/challenge/retrieve.go
@@ -76,6 +76,10 @@ func (store *Store) RetrieveChallenge(ctx context.Context, req *RetrieveChalleng
 	// 4. Fetch challenge info
 	fschall, err := fs.LoadChallenge(req.Id)
 	if err != nil {
+		// If challenge not found, is not an error
+		if _, ok := err.(*errs.ErrChallengeExist); ok {
+			return nil, nil
+		}
 		if err, ok := err.(*errs.ErrInternal); ok {
 			logger.Error(ctx, "loading challenge",
 				zap.Error(err),

--- a/api/v1/instance/retrieve.go
+++ b/api/v1/instance/retrieve.go
@@ -109,6 +109,10 @@ func (man *Manager) RetrieveInstance(ctx context.Context, req *RetrieveInstanceR
 	// 6. If instance does not exist, return error
 	fsist, err := fs.LoadInstance(req.ChallengeId, req.SourceId)
 	if err != nil {
+		// If instance not found, is not an error
+		if _, ok := err.(*errs.ErrInstanceExist); ok {
+			return nil, nil
+		}
 		if err, ok := err.(*errs.ErrInternal); ok {
 			logger.Error(ctx, "loading challenge instance",
 				zap.Error(err),


### PR DESCRIPTION
This PR comes in response to an issue we observed through the NoBrackets 2024.

By returning errors for unexisting resources, the API drastically increased the error rate in OTEL spans/Jaeger monitoring which is semantically invalid: there was no service failure/downgrade, only a check to know if an API object existed or not.
The following screenshot shows the problem: everything went fine, but we had a ~50% error rate on this method. We cannot agree on SLAs with such behavior.

![image](https://github.com/user-attachments/assets/02ec26d9-38c9-413b-ada6-ba9f3ee515a8)
