### PR TITLE
Remove binary artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ swagger-ui/*
 
 # local chall-manager instance
 Pulumi.*.yaml
+
+# generated content from examples
+examples/**/scenario.zip
+examples/**/main

--- a/examples/no-sdk/README.md
+++ b/examples/no-sdk/README.md
@@ -1,0 +1,11 @@
+# No-SDK
+
+The No-SDK example provide you a Chall-Manager-SDK-free code for you to support the main features of a scenario.
+
+You may want to manipulate further your stack or do pre-flight checks, thus do this.
+In most cases, you should **not** do it, especially if you do not know what you are doing.
+
+## Demo
+
+To build the scenario archive you only need to run `./build.sh`.
+It will compile the Pulumi Go code and create the zip archive (`scenario.zip`).

--- a/examples/no-sdk/build.sh
+++ b/examples/no-sdk/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+CGO_ENABLED=0 go build -o main main.go
+zip -r scenario.zip main Pulumi.yaml

--- a/examples/prebuilt/README.md
+++ b/examples/prebuilt/README.md
@@ -1,0 +1,13 @@
+# Prebuilt
+
+The Prebuilt example shows how to make a pre-compiled binary as scenario.
+
+You may want to do it in case:
+- you want **high performances** on the challenge creation (avoid Chall-Manager to compile it on its own)
+- you want **traceability** on the binary thus provide it to Chall-Manager rather than expecting it to check
+- you use a **private dependency** the Chall-Manager has no access to, thus build it locally where it is possible
+
+## Demo
+
+To build the scenario archive you only need to run `./build.sh`.
+It will compile the Pulumi Go code and create the zip archive (`scenario.zip`).

--- a/examples/prebuilt/build.sh
+++ b/examples/prebuilt/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+CGO_ENABLED=0 go build -o main ../teeworlds/main.go
+zip -r scenario.zip main Pulumi.yaml

--- a/go.work.sum
+++ b/go.work.sum
@@ -844,6 +844,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9K
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.0/go.mod h1:qmOFXW2epJhM0qSnUUYpldc7gVz2KMQwJ/QYCDIa7XU=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.23.0/go.mod h1:igFoXX2ELCW06bol23DWPB5BEWfZISOzSP5K2sbLea0=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0/go.mod h1:qztMSjm835F2bXf+5HKAPIS5qsmQDqZna/PgVt4rWtI=
 github.com/hanwen/go-fuse/v2 v2.5.0/go.mod h1:xKwi1cF7nXAOBCXujD5ie0ZKsxc8GGSA1rlMJc+8IJs=
 github.com/hashicorp/consul/api v1.27.0/go.mod h1:JkekNRSou9lANFdt+4IKx3Za7XY0JzzpQjEb4Ivo1c8=
 github.com/hashicorp/cronexpr v1.1.2/go.mod h1:P4wA0KBl9C5q2hABiMO7cp6jcIg96CDh1Efb3g1PWA4=
@@ -869,6 +870,7 @@ github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uG
 github.com/hashicorp/golang-lru v0.6.0 h1:uL2shRDx7RTrOrTCUZEGP/wJUFiUI8QT6E7z5o8jga4=
 github.com/hashicorp/golang-lru v0.6.0/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
 github.com/hashicorp/hcl/v2 v2.17.0/go.mod h1:gJyW2PTShkJqQBKpAmPO3yxMxIuoXkOF2TpqXzrQyx4=
+github.com/hashicorp/hcl/v2 v2.18.0/go.mod h1:ThLC89FV4p9MPW804KVbe/cEXoQ8NZEh+JtMeeGErHE=
 github.com/hashicorp/nomad/api v0.0.0-20230721134942-515895c7690c/go.mod h1:O23qLAZuCx4htdY9zBaO4cJPXgleSFEdq6D/sezGgYE=
 github.com/hashicorp/serf v0.10.1/go.mod h1:yL2t6BqATOLGc5HF7qbFkTfXoPIY0WZdWHfEvMqbG+4=
 github.com/hashicorp/vault/sdk v0.6.1 h1:sjZC1z4j5Rh2GXYbkxn5BLK05S1p7+MhW4AgdUmgRUA=
@@ -1697,6 +1699,7 @@ google.golang.org/protobuf v1.34.1/go.mod h1:c6P6GXX6sHbq/GpV6MGZEdwhWPcYBgnhAHh
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 google.golang.org/protobuf v1.34.3-0.20240816073751-94ecbc261689/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
+google.golang.org/protobuf v1.35.2/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.0/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/DataDog/dd-trace-go.v1 v1.27.1/go.mod h1:Sp1lku8WJMvNV0kjDI4Ni/T7J/U3BO5ct5kEaoVU8+I=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
This PR removes the binary artifacts we could find in the `examples/`.

It will solve the security alert on the subject, and improve further the example explanation by providing a way to reproduce it.