### PR TITLE
Fix janitor to stop once janitored without a ticker

### DIFF
--- a/cmd/chall-manager-janitor/main.go
+++ b/cmd/chall-manager-janitor/main.go
@@ -145,6 +145,7 @@ func run(c *cli.Context) error {
 		if err := janitor(ctx, cli); err != nil {
 			return err
 		}
+		stop()
 	}
 
 	// Listen for the interrupt signal


### PR DESCRIPTION
This PR solves the issue we encountered with the Hack'lantique 2025.

It produced when the janitor was deployed as a cronjob on Kubernetes, so without a ticker. Due to the recent changes in the API to support the ticker (#408), it did not stop once janitoring was completed.