### PR TITLE
Fix ingress exposure missing information for it to work

### DIFF
--- a/examples/exposed-monopod/main.go
+++ b/examples/exposed-monopod/main.go
@@ -25,6 +25,14 @@ func main() {
 			Files: pulumi.StringMap{
 				"/app/flag.txt": variated,
 			},
+			// The following fits for a Traefik-based use case
+			IngressAnnotations: pulumi.ToStringMap(map[string]string{
+				"traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
+			}),
+			IngressNamespace: pulumi.String("networking"),
+			IngressLabels: pulumi.ToStringMap(map[string]string{
+				"app": "traefik",
+			}),
 		}, opts...)
 		if err != nil {
 			return err

--- a/webdocs/challmaker-guides/software-development-kit/index.md
+++ b/webdocs/challmaker-guides/software-development-kit/index.md
@@ -62,7 +62,7 @@ func main() {
 		cm, err := kubernetes.NewExposedMonopod(req.Ctx, &kubernetes.ExposedMonopodArgs{
 			Image:      pulumi.String("myprofile/my-challenge:latest"),
 			Port:       pulumi.Int(8080),
-			ExposeType: kubernetes.ExposeIngress,
+			ExposeType: kubernetes.ExposeNodePort,
 			Hostname:   pulumi.String("brefctf.ctfer.io"),
 			Identity:   pulumi.String(req.Config.Identity),
 		}, opts...)
@@ -70,7 +70,7 @@ func main() {
 			return err
 		}
 
-		resp.ConnectionInfo = pulumi.Sprintf("curl -v https://%s", cm.URL)
+		resp.ConnectionInfo = pulumi.Sprintf("curl -v http://%s", cm.URL)
 		return nil
 	})
 }

--- a/webdocs/tutorials/a-complete-example/index.md
+++ b/webdocs/tutorials/a-complete-example/index.md
@@ -92,11 +92,18 @@ import (
 func main() {
 	sdk.Run(func(req *sdk.Request, resp *sdk.Response, opts ...pulumi.ResourceOption) error {
 		cm, err := kubernetes.NewExposedMonopod(req.Ctx, &kubernetes.ExposedMonopodArgs{
-			Image:      pulumi.String("account/challenge:latest"), // challenge Docker image
-			Port:       pulumi.Int(8080),                          // pod listens on port 8080
-			ExposeType: kubernetes.ExposeIngress,                  // expose the challenge through an ingress (HTTP)
-			Hostname:   pulumi.String("brefctf.ctfer.io"),         // CTF hostname
-			Identity:   pulumi.String(req.Config.Identity),        // identity will be prepended to hostname
+			Image:              pulumi.String("account/challenge:latest"), // challenge Docker image
+			Port:               pulumi.Int(8080),                          // pod listens on port 8080
+			ExposeType:         kubernetes.ExposeIngress,                  // expose the challenge through an ingress (HTTP)
+			Hostname:           pulumi.String("brefctf.ctfer.io"),         // CTF hostname
+			Identity:           pulumi.String(req.Config.Identity),        // identity will be prepended to hostname
+            IngressAnnotations: pulumi.ToStringMap(map[string]string{      // annotations for the ingress to target the service
+				"traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
+			}),
+			IngressNamespace: pulumi.String("networking"),       // the namespace in which the ingress is deployed 
+			IngressLabels: pulumi.ToStringMap(map[string]string{ // the labels of the ingress pods
+				"app": "traefik",
+			}),
 		}, opts...)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR solves the issue we encountered when working on the Hack'lantique 2025.

We were not able to create ingresses due to a lack of information : where is the ingress running ?
Due to no answers available, we could not build the `NetworkPolicy` that accepts traffic from the `IngressController` toward the challenge pods.

In this PR I solve this issue by adding two new parameters : `IngressNamespace` to give the namespace in which the `IngressController` is running, and `IngressLabels` to specify a pod in this namespace rather than every one of them.
At the end of the `provision` function, in the _exposure_ switch, I combine them to create the required `NetworkPolicy`.
It was the occasion to move around some specific code for NodePorts.

I update the webdoc to document those new infos :wink: