### PR TITLE
fix(instance): permit renew if both timeout and until is define

### DIFF
--- a/api/v1/instance/renew.go
+++ b/api/v1/instance/renew.go
@@ -119,7 +119,7 @@ func (man *Manager) RenewInstance(ctx context.Context, req *RenewInstanceRequest
 	}
 
 	// 7. Set new until to now + challenge.timeout if any
-	if fschall.Timeout == nil || fschall.Until != nil {
+	if fschall.Timeout == nil {
 		// This makes sure renewal is possible thanks to a timeout
 		return nil, fmt.Errorf("challenge %s does not accept renewal", req.ChallengeId)
 	}


### PR DESCRIPTION
Hello there ! 

While working on ctfer-io/ctfd-chall-manager#107 I realized that the chall-manager API did not correctly handle the instance renewal request in the case where the challenge defined an `Until` and a `Timeout`. 

This PR remove the (useless) check before the `ComputeUntil` and return a custom message if the computed until is the same of the challenge one (this is mean even if the Players make a renewal request, CM will not update the until of their instances).



