### PR TITLE
Add dependency review on PRs

### DIFF
--- a/.github/workflows/prs.yaml
+++ b/.github/workflows/prs.yaml
@@ -1,0 +1,16 @@
+name: 'Pull Requests reviews'
+
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Checkout Repository'
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0


### PR DESCRIPTION
This PR adds dependency review for PRs, to determine if there will be known vulnerabilities or restrictive licenses introduced in the PRs.