### PR TITLE
Add Pod Security Standard baseline

### DIFF
--- a/deploy/services/parts/chall-manager.go
+++ b/deploy/services/parts/chall-manager.go
@@ -187,6 +187,11 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 			Labels: pulumi.StringMap{
 				"app.kubernetes.io/component": pulumi.String("deploy"),
 				"app.kubernetes.io/part-of":   pulumi.String("chall-manager"),
+				// From https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/security/podsecurity-baseline.yaml
+				"pod-security.kubernetes.io/enforce":         pulumi.String("baseline"),
+				"pod-security.kubernetes.io/enforce-version": pulumi.String("latest"),
+				"pod-security.kubernetes.io/warn":            pulumi.String("baseline"),
+				"pod-security.kubernetes.io/warn-version":    pulumi.String("latest"),
 			},
 		},
 	}, opts...)


### PR DESCRIPTION
This PR adds the Pod Security Standard on the constructed namespace in which challenges are deployed.

See https://raw.githubusercontent.com/kubernetes/website/main/content/en/examples/security/podsecurity-baseline.yaml for labels origin.
