### PR TITLE
feat(deploy): pass kubeconfig rather than creating r/sa/rb

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -50,6 +50,11 @@ config:
     type: boolean
     description: Whether to expose to external networking the Chall-Manager service. DO NOT TURN ON IF YOU DON'T UNDERSTAND THE IMPACT.
     default: false
+  kubeconfig:
+    type: string
+    secret: true
+    description: A kubeconfig to use rather than the default ServiceAccount.
+    default: ""
   otel.endpoint:
     type: string
     description: The OpenTelemetry Collector endpoint to set signals to. (Optional)

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -36,6 +36,7 @@ func main() {
 			}),
 			PVCStorageSize: pulumi.String(cfg.PVCStorageSize),
 			Expose:         cfg.Expose,
+			Kubeconfig:     cfg.Kubeconfig,
 		}
 		if cfg.Etcd != nil {
 			args.EtcdReplicas = pulumi.IntPtr(cfg.Etcd.Replicas)
@@ -77,6 +78,10 @@ type (
 		PVCStorageSize string
 		Expose         bool
 		Otel           *OtelConfig
+
+		// Secrets
+
+		Kubeconfig pulumi.StringOutput
 	}
 
 	EtcdConfig struct {
@@ -106,6 +111,7 @@ func loadConfig(ctx *pulumi.Context) *Config {
 		PVCAccessMode:  cfg.Get("pvc-access-mode"),
 		PVCStorageSize: cfg.Get("pvc-storage-size"),
 		Expose:         cfg.GetBool("expose"),
+		Kubeconfig:     cfg.GetSecret("kubeconfig"),
 	}
 
 	var etcdC EtcdConfig

--- a/deploy/services/chall-manager.go
+++ b/deploy/services/chall-manager.go
@@ -70,6 +70,10 @@ type (
 		// for syntax.
 		PVCStorageSize pulumi.StringInput
 
+		// Kubeconfig is an optional attribute that override the ServiceAccount
+		// created by default for Chall-Manager.
+		Kubeconfig pulumi.StringInput
+
 		Swagger, Expose bool
 
 		Otel *common.OtelArgs
@@ -241,6 +245,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 		PVCAccessModes: args.pvcAccessModes,
 		PVCStorageSize: args.PVCStorageSize,
 		Otel:           nil,
+		Kubeconfig:     args.Kubeconfig,
 	}
 	if args.EtcdReplicas != nil {
 		cmArgs.Etcd = &parts.ChallManagerEtcdArgs{
@@ -306,7 +311,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 		Ticker:               args.JanitorTicker,
 		Mode:                 args.JanitorMode,
 		Otel:                 cmjOtel,
-	})
+	}, opts...)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
This PR adds the capability to pass a kubeconfig to chall-manager rather than creating a role/service account/role binding.
For instance, it enables management of distant cluster rather than deploying Chall-Manager in the same cluster, or even in a cluster at all.

It can be configured as follows.
```bash
pulumi config set --secret kubeconfig "$(cat /path/to/kubeconfig)"
```

Btw CMJ did not have `opts...` so I fix it at same time :wink:

Resolves #651 