### PR TITLE
fix: disable service account auto-mount by default

### DIFF
--- a/sdk/kubernetes/exposed-multipod.go
+++ b/sdk/kubernetes/exposed-multipod.go
@@ -484,6 +484,7 @@ func (emp *exposedMultipod) provision(ctx *pulumi.Context, args ExposedMultipodA
 						Labels: labels,
 					},
 					Spec: &corev1.PodSpecArgs{
+						AutomountServiceAccountToken: pulumi.BoolPtr(true),
 						Containers: corev1.ContainerArray{
 							corev1.ContainerArgs{
 								Name:  args.Identity(),

--- a/sdk/kubernetes/kompose.go
+++ b/sdk/kubernetes/kompose.go
@@ -442,6 +442,17 @@ func (kmp *Kompose) provision(ctx *pulumi.Context, in KomposeArgsOutput, opts ..
 			}
 			return nil
 		},
+		// Disable ServiceAccount auto-mount
+		func(_ context.Context, args *pulumi.ResourceTransformArgs) *pulumi.ResourceTransformResult {
+			if args.Type == "kubernetes:apps/v1:Deployment" {
+				args.Props["spec"].(pulumi.Map)["template"].(pulumi.Map)["spec"].(pulumi.Map)["automountServiceAccountToken"] = pulumi.Bool(false)
+				return &pulumi.ResourceTransformResult{
+					Props: args.Props,
+					Opts:  args.Opts,
+				}
+			}
+			return nil
+		},
 	}))
 
 	// Generate Kubernetes resources


### PR DESCRIPTION
This PR turns off default Kubernetes behavior of mounting the default ServiceAccount into pods. As this is not required (having a SA) and even if it can't be used to pivot thanks to NetworkPolicies, it opens room for potential exploitation when chained with a potential lack of control.
By disabling it, we do not affect the features of these SDK resources, but reinforce the security-by-default posture of the SDK.

Poke @TPGamesNL :)

Resolves #623 