### PR TITLE
Impr/parallel claim pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,6 @@ update-swagger:
 TAG?=dev
 .PHONY: docker
 docker:
-	docker build -t $(REGISTRY)ctferio/chall-manager:$(TAG) -f Dockerfile.chall-manager .
-	docker push $(REGISTRY)ctferio/chall-manager:$(TAG)
-
-	docker build -t $(REGISTRY)ctferio/chall-manager-janitor:$(TAG) -f Dockerfile.chall-manager-janitor .
-	docker push $(REGISTRY)ctferio/chall-manager-janitor:$(TAG)
+	(docker build -t $(REGISTRY)ctferio/chall-manager:$(TAG)         -f Dockerfile.chall-manager .         && docker push $(REGISTRY)ctferio/chall-manager:$(TAG)) &
+	(docker build -t $(REGISTRY)ctferio/chall-manager-janitor:$(TAG) -f Dockerfile.chall-manager-janitor . && docker push $(REGISTRY)ctferio/chall-manager-janitor:$(TAG)) &
+	wait

--- a/api/v1/challenge/update.go
+++ b/api/v1/challenge/update.go
@@ -329,6 +329,12 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 				return
 			}
 
+			// Wash Pulumi files
+			if err := fs.Wash(fschall.Directory, identity); err != nil {
+				cerr <- err
+				return
+			}
+
 			logger.Info(ctx, "deleted instance successfully")
 			common.InstancesUDCounter().Add(ctx, -1)
 		}(work, cerr, identity)

--- a/api/v1/instance/delete.go
+++ b/api/v1/instance/delete.go
@@ -50,7 +50,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 		return nil, errs.ErrInternalNoSub
 	}
 	defer common.LClose(clock)
-	if err := clock.RWLock(ctx); err != nil {
+	if err := clock.RLock(ctx); err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "challenge R lock", zap.Error(multierr.Combine(
 			totw.RUnlock(ctx),
@@ -64,7 +64,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "TOTW R unlock",
 			zap.Error(multierr.Combine(
-				clock.RWUnlock(ctx),
+				clock.RUnlock(ctx),
 				err,
 			)),
 		)
@@ -78,53 +78,41 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 		if err, ok := err.(*errs.ErrInternal); ok {
 			logger.Error(ctx, "loading challenge",
 				zap.Error(multierr.Combine(
-					clock.RWUnlock(ctx),
+					clock.RUnlock(ctx),
 					err,
 				)),
 			)
 			return nil, errs.ErrInternalNoSub
 		}
-		if err := clock.RWUnlock(ctx); err != nil {
+		if err := clock.RUnlock(ctx); err != nil {
 			logger.Error(ctx, "reading challenge from filesystem",
-				zap.Error(clock.RWUnlock(ctx)),
+				zap.Error(clock.RUnlock(ctx)),
 			)
 		}
 		return nil, err
 	}
-	id, ok := fschall.Instances[req.SourceId]
-	if !ok {
-		if err := clock.RWUnlock(ctx); err != nil {
-			logger.Error(ctx, "reading challenge from filesystem",
-				zap.Error(clock.RWUnlock(ctx)),
-			)
-		}
-		return nil, &errs.ErrInstanceExist{
-			ChallengeID: req.ChallengeId,
-			SourceID:    req.SourceId,
-			Exist:       false,
-		}
-	}
-	delete(fschall.Instances, req.SourceId)
 
-	if err := fschall.Save(); err != nil {
-		logger.Error(ctx, "saving challenge on filesystem",
+	// 5. Lock RW instance
+	ctx = global.WithSourceID(ctx, req.SourceId)
+	id, err := fs.FindInstance(req.ChallengeId, req.SourceId)
+	if err != nil {
+		err := &errs.ErrInternal{Sub: err}
+		logger.Error(ctx, "finding instance",
 			zap.Error(multierr.Combine(
-				clock.RWUnlock(ctx),
+				clock.RUnlock(ctx),
 				err,
 			)),
 		)
 		return nil, errs.ErrInternalNoSub
 	}
 
-	// 5. Lock RW instance
-	ctx = global.WithSourceID(ctx, req.SourceId)
 	ctx = global.WithIdentity(ctx, id)
 	ilock, err := common.LockInstance(req.ChallengeId, id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock",
 			zap.Error(multierr.Combine(
-				clock.RWUnlock(ctx),
+				clock.RUnlock(ctx),
 				err,
 			)),
 		)
@@ -135,7 +123,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "challenge instance RW lock",
 			zap.Error(multierr.Combine(
-				clock.RWUnlock(ctx),
+				clock.RUnlock(ctx),
 				err,
 			)),
 		)
@@ -153,14 +141,14 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "listing instances",
 			zap.Error(multierr.Combine(
-				clock.RWUnlock(ctx),
+				clock.RUnlock(ctx),
 				err,
 			)),
 		)
 		return nil, errs.ErrInternalNoSub
 	}
 
-	if err := clock.RWUnlock(ctx); err != nil {
+	if err := clock.RUnlock(ctx); err != nil {
 		logger.Error(ctx, "challenge RW unlock",
 			zap.Error(err),
 		)

--- a/api/v1/instance/renew.go
+++ b/api/v1/instance/renew.go
@@ -84,13 +84,13 @@ func (man *Manager) RenewInstance(ctx context.Context, req *RenewInstanceRequest
 		}
 		return nil, err
 	}
-	id, ok := fschall.Instances[req.SourceId]
-	if !ok {
-		return nil, &errs.ErrInstanceExist{
-			ChallengeID: req.ChallengeId,
-			SourceID:    req.SourceId,
-			Exist:       false,
-		}
+	id, err := fs.FindInstance(req.ChallengeId, req.SourceId)
+	if err != nil {
+		err := &errs.ErrInternal{Sub: err}
+		logger.Error(ctx, "finding instance",
+			zap.Error(err),
+		)
+		return nil, errs.ErrInternalNoSub
 	}
 
 	// 5. Lock RW instance

--- a/global/context.go
+++ b/global/context.go
@@ -1,0 +1,65 @@
+package global
+
+import (
+	"context"
+	"time"
+)
+
+type withoutCtx struct {
+	parent  context.Context
+	without any
+}
+
+var _ context.Context = (*withoutCtx)(nil)
+
+func (withoutCtx) Deadline() (deadline time.Time, ok bool) {
+	return
+}
+
+func (withoutCtx) Done() <-chan struct{} {
+	return nil
+}
+
+func (withoutCtx) Err() error {
+	return nil
+}
+
+func (c withoutCtx) Value(key any) any {
+	if key == c.without {
+		return nil
+	}
+	return c.parent.Value(key)
+}
+
+func WithChallengeID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, challengeKey{}, id)
+}
+
+func WithIdentity(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, identityKey{}, id)
+}
+
+func WithSourceID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, sourceKey{}, id)
+}
+
+func WithoutChallengeID(ctx context.Context) context.Context {
+	return &withoutCtx{
+		parent:  ctx,
+		without: challengeKey{},
+	}
+}
+
+func WithoutIdentity(ctx context.Context) context.Context {
+	return &withoutCtx{
+		parent:  ctx,
+		without: identityKey{},
+	}
+}
+
+func WithoutSourceID(ctx context.Context) context.Context {
+	return &withoutCtx{
+		parent:  ctx,
+		without: sourceKey{},
+	}
+}

--- a/global/log.go
+++ b/global/log.go
@@ -49,18 +49,6 @@ func decaps(ctx context.Context, fields ...zap.Field) []zap.Field {
 	return fields
 }
 
-func WithChallengeID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, challengeKey{}, id)
-}
-
-func WithIdentity(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, identityKey{}, id)
-}
-
-func WithSourceID(ctx context.Context, id string) context.Context {
-	return context.WithValue(ctx, sourceKey{}, id)
-}
-
 var (
 	logger  *Logger
 	logOnce sync.Once

--- a/go.work.sum
+++ b/go.work.sum
@@ -1,10 +1,11 @@
 buf.build/gen/go/bufbuild/bufplugin/connectrpc/go v1.17.0-20241023225133-42bdb4b67625.1/go.mod h1:U16MMbL4PmaOv/vZtIyPwGJrJA0uVNX5sU/uupKidIE=
 buf.build/gen/go/bufbuild/bufplugin/connectrpc/go v1.18.1-20241023225133-42bdb4b67625.1/go.mod h1:U25kpbGQNelEvQOzl27pScJfeNHi8j9khymdeDG3+LQ=
+buf.build/gen/go/bufbuild/bufplugin/connectrpc/go v1.18.1-20250121211742-6d880cc6cc8d.1/go.mod h1:Xixf9QIALSxyoVWM9LH3ga3BNO1vvY+SS37XmNPT5ho=
 buf.build/gen/go/bufbuild/protovalidate/connectrpc/go v1.16.1-20240401165935-b983156c5e99.1/go.mod h1:t9C13HzvpBzXAQHVPPDwlPyRT0BQffj6AFsjLutItKs=
 buf.build/gen/go/bufbuild/protovalidate/connectrpc/go v1.16.2-20240401165935-b983156c5e99.1/go.mod h1:MchZtAkwyKSCO2h1S28YzHjufpTEoe0OY8tuSlGH/Fs=
 buf.build/gen/go/bufbuild/protovalidate/connectrpc/go v1.17.0-20240401165935-b983156c5e99.1/go.mod h1:TLNuswCVOKkYk5k0Q/5feIBfSBIyn8GXdEe++jZKxi4=
 buf.build/gen/go/bufbuild/protovalidate/connectrpc/go v1.18.1-20240401165935-b983156c5e99.1/go.mod h1:472mPnWnhRk2WMztyVVpPRIsCXKWmvrk0kiS+nqV1UA=
-buf.build/go/protovalidate v0.12.0/go.mod h1:q3PFfbzI05LeqxSwq+begW2syjy2Z6hLxZSkP1OH/D0=
+buf.build/gen/go/bufbuild/protovalidate/connectrpc/go v1.18.1-20250423154025-7712fb530c57.1/go.mod h1:XfHG9+bdnDRfPzvMUk4zHjapM8kZGfbmiIgmNIBZnZw=
 cel.dev/expr v0.15.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cel.dev/expr v0.16.0/go.mod h1:TRSuuV7DlVCE/uwv5QbAiW/v8l5O8C4eEPHeu7gf7Sg=
 cel.dev/expr v0.16.1/go.mod h1:AsGA5zb3WruAEQeQng1RZdGEXmBj0jvMWh6l5SnNuC8=
@@ -640,6 +641,7 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/blend/sentry-go v1.0.1/go.mod h1:hgyX3WXen2YBiA0NitlfsXsvS+9ly2YlEBmmmYDgrWY=
 github.com/bradfitz/gomemcache v0.0.0-20230905024940-24af94b03874/go.mod h1:r5xuitiExdLAJ09PR7vBVENGvp4ZuTBeWTGtxuX3K+c=
 github.com/bufbuild/protocompile v0.10.0/go.mod h1:G9qQIQo0xZ6Uyj6CMNz0saGmx2so+KONo8/KrELABiY=
+github.com/bufbuild/protovalidate-go v0.9.3/go.mod h1:2lUDP6fNd3wxznRNH3Nj64VB07+PySeslamkerwP6tE=
 github.com/bufbuild/protoyaml-go v0.1.9/go.mod h1:KCBItkvZOK/zwGueLdH1Wx1RLyFn5rCH7YjQrdty2Wc=
 github.com/bwesterb/go-ristretto v1.2.3/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/ccojocar/zxcvbn-go v1.0.1/go.mod h1:g1qkXtUSvHP8lhHp5GrSmTz6uWALGRMQdw6Qnz/hi60=
@@ -657,6 +659,7 @@ github.com/charmbracelet/x/ansi v0.4.2/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoC
 github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.0/go.mod h1:GVxgxAbjUrmpvIINHIQnJJKpMlHiZ4cktEQCN6GWyF0=
+github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
 github.com/cilium/ebpf v0.11.0/go.mod h1:WE7CZAnqOL2RouJ4f1uyNhqr2P4CCvXFIqdRDUgWsVs=
 github.com/cilium/ebpf v0.16.0/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
 github.com/cncf/udpa/go v0.0.0-20200629203442-efcf912fb354/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
@@ -745,11 +748,13 @@ github.com/envoyproxy/go-control-plane/ratelimit v0.1.0 h1:/G9QYbddjL25KvtKTv3an
 github.com/envoyproxy/go-control-plane/ratelimit v0.1.0/go.mod h1:Wk+tMFAFbCXaJPzVVHnPgRKdUdwW/KdbRt94AzgRee4=
 github.com/envoyproxy/protoc-gen-validate v1.0.2/go.mod h1:GpiZQP3dDbg4JouG/NNS7QWXpgx6x8QiMKdmN72jogE=
 github.com/envoyproxy/protoc-gen-validate v1.0.4/go.mod h1:qys6tmnRsYrQqIhm2bvKZH4Blx/1gTIZ2UKVY1M+Yew=
+github.com/envoyproxy/protoc-gen-validate v1.2.1/go.mod h1:d/C80l/jxXLdfEIhX1W2TmLfsJ31lvEjwamM4DxlWXU=
 github.com/erikgeiser/promptkit v0.9.0/go.mod h1:pU9dtogSe3Jlc2AY77EP7R4WFP/vgD4v+iImC83KsCo=
 github.com/ettle/strcase v0.1.1/go.mod h1:hzDLsPC7/lwKyBOywSHEP89nt2pDgdy+No1NBA9o9VY=
 github.com/evanphx/json-patch v5.6.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/facette/natsort v0.0.0-20181210072756-2cd4dd1e2dcb/go.mod h1:bH6Xx7IW64qjjJq8M2u4dxNaBiDfKK+z/3eGDpXEQhc=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
+github.com/felixge/fgprof v0.9.5/go.mod h1:yKl+ERSa++RYOs32d8K6WEXCB4uXdLls4ZaZPpayhMM=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/francoispqt/gojay v1.2.13/go.mod h1:ehT5mTG4ua4581f1++1WLG0vPdaA9HaiDsoyrBGkyDY=
 github.com/frankban/quicktest v1.14.3/go.mod h1:mgiwOwqx65TmIk1wJ6Q7wvnVMocbUorkibMOrVTHZps=
@@ -963,6 +968,7 @@ github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
+github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
@@ -992,6 +998,7 @@ github.com/jonboulle/clockwork v0.2.2 h1:UOGuzwb1PwsrDAObMuhUnj0p5ULPj8V/xJ7Kx9q
 github.com/jonboulle/clockwork v0.4.0/go.mod h1:xgRqUGwRcjKCO1vbZUEtSLrqKoPSsUpK7fnezOII0kc=
 github.com/josephspurrier/goversioninfo v1.4.0/go.mod h1:JWzv5rKQr+MmW+LvM412ToT/IkYDZjaclF2pKDss8IY=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -1025,6 +1032,7 @@ github.com/lyft/protoc-gen-star/v2 v2.0.4-0.20230330145011-496ad1ac90a4/go.mod h
 github.com/magefile/mage v1.14.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
 github.com/magiconair/properties v1.8.7/go.mod h1:Dhd985XPs7jluiymwWYZ0G4Z61jb3vdS329zhj2hYo0=
 github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.17/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -1103,6 +1111,7 @@ github.com/pierrec/lz4 v2.6.1+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi
 github.com/pierrec/lz4/v4 v4.1.15/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.18/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
+github.com/pkg/profile v1.7.0/go.mod h1:8Uer0jas47ZQMJ7VD+OHknK4YDY07LPUC6dEvqDjvNo=
 github.com/pkg/sftp v1.13.1/go.mod h1:3HaPG6Dq1ILlpPZRO0HVMrsydcdLt6HRDccSgb87qRg=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
 github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10/go.mod h1:t/avpk3KcrXxUnYOhZhMXJlSEyie6gQbtLq5NM3loB8=
@@ -1768,6 +1777,7 @@ google.golang.org/genproto/googleapis/api v0.0.0-20241209162323-e6fa225c2576/go.
 google.golang.org/genproto/googleapis/api v0.0.0-20250102185135-69823020774d/go.mod h1:2v7Z7gP2ZUOGsaFyxATQSRoBnKygqVq2Cwnvom7QiqY=
 google.golang.org/genproto/googleapis/api v0.0.0-20250106144421-5f5ef82da422/go.mod h1:b6h1vNKhxaSoEI+5jc3PJUCustfli/mRab7295pY7rw=
 google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a/go.mod h1:3kWAYMk1I75K4vykHtKt2ycnOgpA6974V7bREqbsenU=
+google.golang.org/genproto/googleapis/api v0.0.0-20250428153025-10db94c68c34/go.mod h1:0awUlEkap+Pb1UMeJwJQQAdJQrt3moU7J2moTy69irI=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20231030173426-d783a09b4405/go.mod h1:GRUCuLdzVqZte8+Dl/D4N25yLzcGqqWaYkeVOwulFqw=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20231212172506-995d672761c0/go.mod h1:guYXGPwC6jwxgWKW5Y405fKWOFNwlvUlUnzyp9i0uqo=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:SCz6T5xjNXM4QFPRwxHcfChp7V+9DcXR3ay2TkHR8Tg=
@@ -1831,6 +1841,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250227231956-55c901821b1e/go.mod h1:LuRYeWDFV6WOn90g357N17oMCaxpgCnbi/44qJvDn2I=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250409194420-de1ac958c67a/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=

--- a/pkg/fs/challenge.go
+++ b/pkg/fs/challenge.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
@@ -117,6 +118,16 @@ func (chall *Challenge) Save() error {
 func (chall *Challenge) Delete() error {
 	dir := ChallengeDirectory(chall.ID)
 	if err := os.RemoveAll(dir); err != nil {
+		return &errs.ErrInternal{Sub: err}
+	}
+	return nil
+}
+
+// Wash the Pulumi.<identity>.yaml file of a challenge given its directory,
+// as it is not performed by Pulumi on stack destroy but is an implied
+// operation in our context.
+func Wash(challDir, identity string) error {
+	if err := os.Remove(filepath.Join(challDir, fmt.Sprintf("Pulumi.%s.yaml", identity))); err != nil {
 		return &errs.ErrInternal{Sub: err}
 	}
 	return nil

--- a/pkg/fs/challenge.go
+++ b/pkg/fs/challenge.go
@@ -17,8 +17,6 @@ import (
 type Challenge struct {
 	ID        string `json:"id"`
 	Directory string `json:"directory"`
-	// Instances is a map of source id to the instance they claimed/deployed.
-	Instances map[string]string `json:"instances,omitempty"`
 	// must be kept up coherent with directory content as its sha256 sum of base64(zip(content))
 	Hash       string            `json:"hash"`
 	Until      *time.Time        `json:"until,omitempty"`

--- a/pkg/fs/common.go
+++ b/pkg/fs/common.go
@@ -21,7 +21,8 @@ const (
 // while avoiding filesystem manipulation (e.g. path traversal).
 func Hash(id string) string {
 	h := md5.New()
-	sum := h.Sum([]byte(id))
+	_, _ = h.Write([]byte(id))
+	sum := h.Sum(nil)
 	return hex.EncodeToString(sum)
 }
 

--- a/pkg/fs/instance.go
+++ b/pkg/fs/instance.go
@@ -38,7 +38,7 @@ func (ist *Instance) Claim(sourceID string) error {
 	if _, err := os.Stat(claimPath); err == nil {
 		return fmt.Errorf("instance %s/%s is already claimed", ist.ChallengeID, ist.Identity)
 	}
-	return os.WriteFile(claimPath, []byte(sourceID), 0600)
+	return os.WriteFile(claimPath, []byte(sourceID), 0o600)
 }
 
 func (ist *Instance) IsClaimed() bool {
@@ -71,7 +71,11 @@ func FindInstance(challID, sourceID string) (string, error) {
 			return ist, nil
 		}
 	}
-	return "", fmt.Errorf("instance of challenge %s not found for source %s", challID, sourceID)
+	return "", &errs.ErrInstanceExist{
+		ChallengeID: challID,
+		SourceID:    sourceID,
+		Exist:       false,
+	}
 }
 
 func InstanceDirectory(challID, identity string) string {

--- a/pkg/scenario/validate.go
+++ b/pkg/scenario/validate.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ctfer-io/chall-manager/global"
 	errs "github.com/ctfer-io/chall-manager/pkg/errors"
+	"github.com/ctfer-io/chall-manager/pkg/fs"
 	"github.com/ctfer-io/chall-manager/pkg/iac"
 	"github.com/pulumi/pulumi/sdk/v3/go/auto"
 )
@@ -36,6 +37,9 @@ func Validate(ctx context.Context, dir string, add map[string]string) error {
 	// Preview stack to ensure it build without error
 	if _, err := stack.Preview(ctx); err != nil {
 		return &errs.ErrScenario{Sub: err}
+	}
+	if err := fs.Wash(dir, rand); err != nil {
+		return err
 	}
 
 	return nil

--- a/webdocs/design/pooler/index.md
+++ b/webdocs/design/pooler/index.md
@@ -4,6 +4,7 @@ description: How to reach tremendous performances by pre-provisionning instances
 categories: [Explanations]
 tags: [Infrastructure]
 weight: 10
+math: true
 ---
 
 {{< alert title="Warning" color="warning">}}
@@ -80,6 +81,20 @@ On a big scenario (e.g. a VM-based lab) that could take minutes to complete, the
 When a challenge is updated, if there is any change to the pooler configuration, the planned pool size is computed. Then the difference between the state and the plan is performed. If there are too many pooled instances running, the difference is deleted. Similarly, if there ain't enough, the difference is created. All untouched instances are updated as for the claimed instances.
 
 The algorithm for this won't be detailed but lays [here](https://github.com/ctfer-io/chall-manager/tree/main/pkg/delta).
+
+## Impact
+
+To illustrate the impact problem of the pooler, let's consider an instance which costs 2 vCPUs, 8 Go of RAM and 20 Go of disk space. In this factice infrastructure, the limitating component is the CPU.
+By itself, the infrastructure's capabilities might be sufficient to handle enough instances for all players, but with adjacent challenges and the backbone it becomes unviable. That way, you can't consider pre-provisionning all instances, and have not enough data to pre-provision part of them. A deployment takes 5 minutes so leads to an unacceptable quality for your players: you must use the pooler.
+
+Using the pooler is a balance between time and experience from the [Player](/docs/chall-manager/glossary#player) and [ChallMaker](/docs/chall-manager/glossary#challmaker) perspective, but a balance between performances and costs for the [Ops](/docs/chall-manager/glossary#ops) and [Admins](/docs/chall-manager/glossary#administrator) perspective. When we discuss **costs** we consider the use of physical resources (e.g. CPU, RAM, disk), and the corresponding financial costs from a host/cloud service provider. This double balance between quality and costs leads to an undecidable problem.
+
+To help in the decision, we recommend you consider the advantage of having instances in the pool depending mostly on the cost of one instance.
+Under high load, there might be instances in the pool where the global knowledge should recommend not having some. This issue can simply be dealt with by updating the challenge with no change (it triggers the delta algorithm). Given these conditions, the worst case (infrastructure impact) is given by the sum of all individuals costs \\( c_i \\) of every possible instances in \\( \mathscr{I} \\): \\( cost = \sum_{i = 0 }^{\left| \mathscr{I} \right|} c_i \\).
+
+By considering the individual cost \\( c_i \\) even for all instances as \\( c \\), it can be simplified as \\( cost = c \times \left| \mathscr{P} \right| = c \times \big(\left| pool \right| + \left| sources \right| \big) \\), with \\( \left| pool \right| \\) the minimum pool size (`min` attribute) and \\( \left| sources \right| \\) the total number of expected players in the worst case.
+
+In prose, the **worst case cost** on infrastructure is given by the **total number of players and the minimum pool size multiplied by the mean cost of a single instance**. This last can be determined by the limitating characteristic of the hosting infrastructure.
 
 ## Use cases
 

--- a/webdocs/glossary/index.md
+++ b/webdocs/glossary/index.md
@@ -48,7 +48,7 @@ This is an essential role for a CTF event, as without them, the CTF would simply
 Notice it is the **responsibility of the ChallMaker** to make its challenge **playable**, not the [Ops](#ops).
 If you can't make your challenge run into pre-prod/prod, you can't blame the Ops.
 
-(S)He collaborates with plenty profiles:
+They collaborate with plenty profiles:
 - other ChallMakers to debate its ideas and assess the difficulty.
 - [Ops](#ops) to make sure its challenges can reach production smoothly.
 - [Admins](#administrator) to discuss the technical feasibility of its challenges, for instance if it requires FPGAs, online platforms as GCP or AWS, etc. or report on the status of the CTF.
@@ -61,7 +61,7 @@ They do not need to be security experts, but might probably be due to the commun
 
 They are the rulers of the infrastructure, its architecture and its incidents. ChallMakers have both fear and admiration on them, as they enable playing complex scenarios but are one click away of destructing everything.
 
-(S)He collaborates with various profiles:
+They collaborate with various profiles:
 - other Ops as a rubber ducky, a mental support during an outage or simply to work in group.
 - [ChallMakers](#challmaker) to assist writing the [scenarios](#scenario) in case of a difficulty or a specific infrastructure architecture or requirement.
 - [Admins](#administrator) to report on the current lifecycle of the infrastructures, the incidents, or provide ideas for evolutions such as a partnership.
@@ -69,6 +69,6 @@ They are the rulers of the infrastructure, its architecture and its incidents. C
 
 ## Administrator
 
-The Administrator is the showcase of the event. (S)He takes responsibility and decisions during the creation process of the event, make sure to synchronize teams throughout the development of the artistic and technical ideas, and manage partnerships if necessary. They are the managers through the whole event, before and after, not only during the CTF.
+The Administrator is the showcase of the event. They take responsibility and decisions during the creation process of the event, make sure to synchronize teams throughout the development of the artistic and technical ideas, and manage partnerships if necessary. They are the managers through the whole event, before and after, not only during the CTF.
 
-(S)He basically collaborates with everyone, which is a double-edged sword: you take the gratification of the whole effort, but have no time to rest.
+They basically collaborate with everyone, which is a double-edged sword: you take the gratification of the whole effort, but have no time to rest.


### PR DESCRIPTION
This PR resolves the issues of parallelism and in-pool instances.
An instance is claimed iif there is a `claim` file in the instance directory, containing a non-empty source ID. That way the filesystem API for instances can be re-written with R locks rather than RW which blocked parallel requests.

It also amends the design documentation with recommendations on determining the worst case on infrastructure, draft written by @NicoFgrx .

:rotating_light: **BREAKING CHANGES** :rotating_light: 
The filesystem API described in this PR is non-retrocompatible, even with the previous patch. Users should completely backup there configuration before migration.