### PR TITLE
feat:add metrics attributes for dashboards

### DIFF
--- a/api/v1/challenge/delete.go
+++ b/api/v1/challenge/delete.go
@@ -6,6 +6,7 @@ import (
 
 	json "github.com/goccy/go-json"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -167,7 +168,10 @@ func (store *Store) DeleteChallenge(ctx context.Context, req *DeleteChallengeReq
 				return
 			}
 
-			common.InstancesUDCounter().Add(ctx, -1)
+			sourceID, _ := fs.LookupClaim(fsist.ChallengeID, fsist.Identity)
+			common.InstancesUDCounter().Add(ctx, -1,
+				metric.WithAttributeSet(common.InstanceAttrs(req.Id, sourceID, sourceID != "")),
+			)
 		}(relock, work, cerr, identity)
 	}
 

--- a/api/v1/challenge/update.go
+++ b/api/v1/challenge/update.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -336,7 +337,9 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 			}
 
 			logger.Info(ctx, "deleted instance successfully")
-			common.InstancesUDCounter().Add(ctx, -1)
+			common.InstancesUDCounter().Add(ctx, -1,
+				metric.WithAttributeSet(common.InstanceAttrs(req.Id, "", true)),
+			)
 		}(work, cerr, identity)
 	}
 

--- a/api/v1/common/metrics.go
+++ b/api/v1/common/metrics.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/ctfer-io/chall-manager/global"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 )
 
@@ -39,4 +40,16 @@ func InstancesUDCounter() metric.Int64UpDownCounter {
 		instancesUDCounter = cnt
 	})
 	return instancesUDCounter
+}
+
+func InstanceAttrs(challID, sourceID string, pool bool) attribute.Set {
+	attrs := []attribute.KeyValue{
+		attribute.String("challenge", challID),
+		attribute.Bool("pool", pool),
+	}
+	if sourceID != "" {
+		attrs = append(attrs, attribute.String("source", sourceID))
+	}
+
+	return attribute.NewSet(attrs...)
 }

--- a/api/v1/instance/create.go
+++ b/api/v1/instance/create.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"time"
 
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -374,7 +375,9 @@ func (man *Manager) CreateInstance(ctx context.Context, req *CreateInstanceReque
 	}
 
 	logger.Info(ctx, "instance created successfully")
-	common.InstancesUDCounter().Add(ctx, 1)
+	common.InstancesUDCounter().Add(ctx, 1,
+		metric.WithAttributeSet(common.InstanceAttrs(req.ChallengeId, req.SourceId, false)),
+	)
 
 	// i. Unlock RW instance
 	if err := ilock.RWUnlock(ctx); err != nil {

--- a/api/v1/instance/delete.go
+++ b/api/v1/instance/delete.go
@@ -5,6 +5,7 @@ import (
 
 	json "github.com/goccy/go-json"
 	"github.com/pulumi/pulumi/sdk/v3/go/common/apitype"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -231,7 +232,9 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 	}
 
 	logger.Info(ctx, "deleted instance successfully")
-	common.InstancesUDCounter().Add(ctx, -1)
+	common.InstancesUDCounter().Add(ctx, -1,
+		metric.WithAttributeSet(common.InstanceAttrs(req.ChallengeId, req.SourceId, false)),
+	)
 
 	// Start concurrent routine that will refill the pool if we are now under
 	// the threshold (i.e. max).

--- a/api/v1/instance/spin.go
+++ b/api/v1/instance/spin.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ctfer-io/chall-manager/pkg/iac"
 	"github.com/ctfer-io/chall-manager/pkg/identity"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/multierr"
 	"go.uber.org/zap"
@@ -147,7 +148,9 @@ func SpinUp(ctx context.Context, challengeID string) {
 	}
 
 	logger.Info(ctx, "instance registered in pool")
-	common.InstancesUDCounter().Add(ctx, 1)
+	common.InstancesUDCounter().Add(ctx, 1,
+		metric.WithAttributeSet(common.InstanceAttrs(challengeID, "", true)),
+	)
 
 	// 11. Save fsist
 	if err := fsist.Save(); err != nil {


### PR DESCRIPTION
This PR adds metric attributes for dashboards, especially for instances, as:
- `challenge` the ID of the challenge an instance ;
- `source` the ID of the source that requested an instance (might not be present for pooled instances) ;
- `pool` indicate whether the instance is being integrated in the pool.

Resolves #627