### PR TITLE
impr: add requests and limits to deploy

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -63,6 +63,22 @@ config:
     secret: true
     description: A kubeconfig to use rather than the default ServiceAccount.
     default: ""
+  requests.cpu:
+    type: string
+    description: The number of CPUs to use.
+    default: "1.0"
+  requests.memory:
+    type: string
+    description: The memory size to use.
+    default: "1Gi"
+  limits.cpu:
+    type: string
+    description: The maximum number of CPUs to use.
+    default: "4.0"
+  limits.memory:
+    type: string
+    description: The maximum memory size to use.
+    default: "5Gi"
   otel.endpoint:
     type: string
     description: The OpenTelemetry Collector endpoint to set signals to. (Optional)

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -38,6 +38,8 @@ func main() {
 			Expose:         cfg.Expose,
 			RomeoClaimName: pulumi.String(cfg.RomeoClaimName),
 			Kubeconfig:     cfg.Kubeconfig,
+			Requests:       pulumi.ToStringMap(cfg.Requests),
+			Limits:         pulumi.ToStringMap(cfg.Limits),
 		}
 		if cfg.Etcd != nil {
 			args.EtcdReplicas = pulumi.IntPtr(cfg.Etcd.Replicas)
@@ -80,6 +82,8 @@ type (
 		Expose         bool
 		LogLevel       string
 		RomeoClaimName string
+		Requests       map[string]string
+		Limits         map[string]string
 		Otel           *OtelConfig
 
 		// Secrets
@@ -117,6 +121,14 @@ func loadConfig(ctx *pulumi.Context) *Config {
 		Expose:         cfg.GetBool("expose"),
 		RomeoClaimName: cfg.Get("romeo-claim-name"),
 		Kubeconfig:     cfg.GetSecret("kubeconfig"),
+	}
+
+	if err := cfg.TryObject("requests", &c.Requests); err != nil {
+		panic(err)
+	}
+
+	if err := cfg.TryObject("limits", &c.Limits); err != nil {
+		panic(err)
 	}
 
 	var etcdC EtcdConfig

--- a/deploy/services/chall-manager.go
+++ b/deploy/services/chall-manager.go
@@ -80,6 +80,14 @@ type (
 		// created by default for Chall-Manager.
 		Kubeconfig pulumi.StringInput
 
+		// Requests for the Chall-Manager container. For more infos:
+		// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+		Requests pulumi.StringMapInput
+
+		// Limits for the Chall-Manager container. For more infos:
+		// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+		Limits pulumi.StringMapInput
+
 		Swagger, Expose bool
 
 		Otel *common.OtelArgs
@@ -255,6 +263,8 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 		Otel:           nil,
 		RomeoClaimName: args.RomeoClaimName,
 		Kubeconfig:     args.Kubeconfig,
+		Requests:       args.Requests,
+		Limits:         args.Limits,
 	}
 	if args.EtcdReplicas != nil {
 		cmArgs.Etcd = &parts.ChallManagerEtcdArgs{


### PR DESCRIPTION
This PR adds deployment requests and limits to Chall-Manager container. It defaults them to a low size such that common deployments does not suffer from outages from caching compilations consuming all resources on the node.

Resolves #678 