### PR TITLE
feat: add romeo claim name mount for coverage export

### DIFF
--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -54,6 +54,10 @@ config:
     type: boolean
     description: Whether to expose to external networking the Chall-Manager service. DO NOT TURN ON IF YOU DON'T UNDERSTAND THE IMPACT.
     default: false
+  romeo-claim-name:
+    type: string
+    description: If set, will turn on the coverage export of Chall-Manager for later download.
+    default: ""
   kubeconfig:
     type: string
     secret: true

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -36,6 +36,7 @@ func main() {
 			}),
 			PVCStorageSize: pulumi.String(cfg.PVCStorageSize),
 			Expose:         cfg.Expose,
+			RomeoClaimName: pulumi.String(cfg.RomeoClaimName),
 			Kubeconfig:     cfg.Kubeconfig,
 		}
 		if cfg.Etcd != nil {
@@ -78,6 +79,7 @@ type (
 		PVCStorageSize string
 		Expose         bool
 		LogLevel       string
+		RomeoClaimName string
 		Otel           *OtelConfig
 
 		// Secrets
@@ -113,6 +115,7 @@ func loadConfig(ctx *pulumi.Context) *Config {
 		PVCAccessMode:  cfg.Get("pvc-access-mode"),
 		PVCStorageSize: cfg.Get("pvc-storage-size"),
 		Expose:         cfg.GetBool("expose"),
+		RomeoClaimName: cfg.Get("romeo-claim-name"),
 		Kubeconfig:     cfg.GetSecret("kubeconfig"),
 	}
 

--- a/deploy/services/chall-manager.go
+++ b/deploy/services/chall-manager.go
@@ -73,6 +73,9 @@ type (
 		// for syntax.
 		PVCStorageSize pulumi.StringInput
 
+		// RomeoClaimName, if set, will turn on the coverage export of Chall-Manager for later download.
+		RomeoClaimName pulumi.StringInput
+
 		// Kubeconfig is an optional attribute that override the ServiceAccount
 		// created by default for Chall-Manager.
 		Kubeconfig pulumi.StringInput
@@ -250,6 +253,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 		PVCAccessModes: args.pvcAccessModes,
 		PVCStorageSize: args.PVCStorageSize,
 		Otel:           nil,
+		RomeoClaimName: args.RomeoClaimName,
 		Kubeconfig:     args.Kubeconfig,
 	}
 	if args.EtcdReplicas != nil {


### PR DESCRIPTION
This PR adds the capability to deploy a [Romeo environment](https://github.com/ctfer-io/romeo/tree/main/environment) to export coverage data, mostly for tests coverage purposes.

It the key `romeo-claim-name` is set to a non-empty value in the Pulumi stack, coverage export is automatically turned on and bound to the PVC claim name pointed out within the namespace.