### PR TITLE
fix: don't pass production logger to etcd

### DIFF
--- a/pkg/lock/etcd.go
+++ b/pkg/lock/etcd.go
@@ -27,7 +27,7 @@ func getClient() *clientv3.Client {
 			Endpoints: global.Conf.Lock.EtcdEndpoints,
 			Username:  global.Conf.Lock.EtcdUsername,
 			Password:  global.Conf.Lock.EtcdPassword,
-			Logger:    global.Log().Sub,
+			Logger:    zap.NewNop(), // Disable logger for etcd as it spams logs
 			DialOptions: []grpc.DialOption{
 				grpc.WithStatsHandler(otelgrpc.NewClientHandler()), // propagate OTEL span info
 			},


### PR DESCRIPTION
With this PR I suggest we modify something that has been **disturbing for quite a while** when deploying to production : `etcd` spams logs with unwanted warnings about things we do not need.

My _simple_ proposal is to pass it a `zap.NewNop` logger such that it logs to nowhere rather than the production logger.
