### PR TITLE
docs: add 24h IUT 2025 to trophy list

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ With Chall-Manager, you are now able to abstract this all thus don't require to 
 
 ## Trophy list
 
-The following list contains all known events were Chall-Manager has been operated in production:
-Please [open an issue](https://github.com/ctfer-io/chall-manager/issues/new) to add your event to the list if we did not ourself.
+The following list contains all known events were Chall-Manager has been operated in production (YYYY/MM/DD):
 
 - 2024/11/20 [NoBracketsCTF 2024](https://github.com/nobrackets-ctf/NoBrackets-2024)
 - 2025/02/09 [ICAISC 2025](https://www.linkedin.com/feed/update/urn:li:ugcPost:7295762712364544001/?actorCompanyId=103798607)
 - 2025/03/08 Hack'lantique 2025
+- 2025/05/24 [24h IUT 2025](https://www.linkedin.com/feed/update/urn:li:activity:7332827877123506177/)
+
+Please [open an issue](https://github.com/ctfer-io/chall-manager/issues/new) to add your event to the list if we did not ourself.
 
 ## Development setup
 


### PR DESCRIPTION
This PR adds the 24h IUT 2025 event to the trophy list.