### PR TITLE
docs: add WhiteHats TrojanCTF 2025 to trophy list

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following list contains all known events were Chall-Manager has been operate
 - 2024/11/20 [NoBracketsCTF 2024](https://github.com/nobrackets-ctf/NoBrackets-2024)
 - 2025/02/09 [ICAISC 2025](https://www.linkedin.com/feed/update/urn:li:ugcPost:7295762712364544001/?actorCompanyId=103798607)
 - 2025/03/08 Hack'lantique 2025
+- 2025/05/17 [WhiteHats TrojanCTF 2025](https://github.com/ESHA-Trojan/TrojanCTF-2025-public)
 - 2025/05/24 [24h IUT 2025](https://www.linkedin.com/feed/update/urn:li:activity:7332827877123506177/)
 
 Please [open an issue](https://github.com/ctfer-io/chall-manager/issues/new) to add your event to the list if we did not ourself.


### PR DESCRIPTION
This PR adds the WhiteHats TrojanCTF 2025 to the trophy list, with a link to the GH repository for challenges (where we can find multiple scenarios source code).

Poke @TPGamesNL