### PR TITLE
impr: add buf lint and publish on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 permissions:
   contents: read
+  pull-requests: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,3 +72,12 @@ jobs:
       
       - name: go-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+
+  buf-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd # v1.2.0
+        with:
+          push: false
+          lint: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,14 @@ permissions:
   contents: read
 
 jobs:
+  buf:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: bufbuild/buf-action@c231a1aa9281e5db706c970f468f0744a37561fd # v1.2.0
+        with:
+          token: ${{ secrets.BUF_TOKEN }}
+
   goreleaser:
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}

--- a/api/v1/challenge/challenge.proto
+++ b/api/v1/challenge/challenge.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package api.v1.challenge;
 
+import "api/v1/instance/instance.proto";
 import "google/api/annotations.proto";
 import "google/api/field_behavior.proto";
 import "google/protobuf/duration.proto";
@@ -9,7 +10,6 @@ import "google/protobuf/empty.proto";
 import "google/protobuf/field_mask.proto";
 import "google/protobuf/timestamp.proto";
 import "protoc-gen-openapiv2/options/annotations.proto";
-import "api/v1/instance/instance.proto";
 
 option go_package = "github.com/ctfer-io/chall-manager/api/v1/challenge;challenge";
 
@@ -18,184 +18,220 @@ option go_package = "github.com/ctfer-io/chall-manager/api/v1/challenge;challeng
 // Through this store, the challenge implements all CRUD operations necessary to handle a
 // lifecycle.
 service ChallengeStore {
-    // Before spinning up instances of a challenge, you need to register it.
-    // That is the goal of CreateChallenge.
-    // If will perform validation on your inputs and especially on the scenario.
-    rpc CreateChallenge(CreateChallengeRequest) returns (Challenge) {
-        option(google.api.http) = {
-            post: "/api/v1/challenge"
-            body: "*"
-        };
-    }
+  // Before spinning up instances of a challenge, you need to register it.
+  // That is the goal of CreateChallenge.
+  // If will perform validation on your inputs and especially on the scenario.
+  rpc CreateChallenge(CreateChallengeRequest) returns (Challenge) {
+    option (google.api.http) = {
+      post: "/api/v1/challenge"
+      body: "*"
+    };
+  }
 
-    // Once saved, you can retrieve the challenge information.
-    // If it has not been created yet, returns an error.
-    // If the challenge has instances running, returns their information too.
-    rpc RetrieveChallenge(RetrieveChallengeRequest) returns (Challenge) {
-        option(google.api.http) = {
-            get: "/api/v1/challenge/{id}"
-        };
-    }
+  // Once saved, you can retrieve the challenge information.
+  // If it has not been created yet, returns an error.
+  // If the challenge has instances running, returns their information too.
+  rpc RetrieveChallenge(RetrieveChallengeRequest) returns (Challenge) {
+    option (google.api.http) = {get: "/api/v1/challenge/{id}"};
+  }
 
-    // Query all challenges information and their instances running.
-    rpc QueryChallenge(google.protobuf.Empty) returns (stream Challenge) {
-        option(google.api.http) = {
-            get: "/api/v1/challenge"
-        };
-    }
+  // Query all challenges information and their instances running.
+  rpc QueryChallenge(google.protobuf.Empty) returns (stream Challenge) {
+    option (google.api.http) = {get: "/api/v1/challenge"};
+  }
 
-    // A challenge can evolve through time, and on live.
-    // The goal of UpdateChallenge is to handle those evolves.
-    // If the until changes, sets it up to running instances.
-    // If the timeout changes, set running instances until to the last renewal increased by
-    // the new timeout.
-    // If the scenario changes, update the running instances, but even if this is
-    // technically possible we do not recommend it has we do not look for infrastructure
-    // drift. 
-    rpc UpdateChallenge(UpdateChallengeRequest) returns (Challenge) {
-        option(google.api.http) = {
-            patch: "/api/v1/challenge/{id}"
-            body: "*"
-        };
-    }
+  // A challenge can evolve through time, and on live.
+  // The goal of UpdateChallenge is to handle those evolves.
+  // If the until changes, sets it up to running instances.
+  // If the timeout changes, set running instances until to the last renewal increased by
+  // the new timeout.
+  // If the scenario changes, update the running instances, but even if this is
+  // technically possible we do not recommend it has we do not look for infrastructure
+  // drift.
+  rpc UpdateChallenge(UpdateChallengeRequest) returns (Challenge) {
+    option (google.api.http) = {
+      patch: "/api/v1/challenge/{id}"
+      body: "*"
+    };
+  }
 
-    // At the end of its life, a challenge can be deleted.
-    // If it has running instances, it will spin them down.
-    rpc DeleteChallenge(DeleteChallengeRequest) returns (google.protobuf.Empty) {
-        option(google.api.http) = {
-            delete: "/api/v1/challenge/{id}"
-        };
-    }
+  // At the end of its life, a challenge can be deleted.
+  // If it has running instances, it will spin them down.
+  rpc DeleteChallenge(DeleteChallengeRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/api/v1/challenge/{id}"};
+  }
 }
 
 // The request to create a challenge.
 message CreateChallengeRequest {
-    // The challenge identifier.
-    string id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier.
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The scenario of the challenge, i.e. the Pulumi infrastructure factory.
-    // Please look at the sdk documentation to understand how to write it.
-    // Technically, it is the base64(zip(<directory>)).
-    string scenario = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"base64(zip(.))\""}, (google.api.field_behavior) = REQUIRED];
-    
-    // The timeout after which the janitor will have permission to delete the instance.
-    google.protobuf.Duration timeout = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The scenario of the challenge, i.e. the Pulumi infrastructure factory.
+  // Please look at the sdk documentation to understand how to write it.
+  // Technically, it is the base64(zip(<directory>)).
+  string scenario = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"base64(zip(.))\""},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The date after which the janitor will have permission to delete the instance.
-    google.protobuf.Timestamp until = 5 [(google.api.field_behavior) = OPTIONAL];
+  // The timeout after which the janitor will have permission to delete the instance.
+  google.protobuf.Duration timeout = 4 [(google.api.field_behavior) = OPTIONAL];
 
-    // A key=value additional configuration to pass to the instance when created.
-    map<string, string> additional = 6 [(google.api.field_behavior) = OPTIONAL];
+  // The date after which the janitor will have permission to delete the instance.
+  google.protobuf.Timestamp until = 5 [(google.api.field_behavior) = OPTIONAL];
 
-    // Min from the pooler feature.
-    // Determine the minimum number of instances we want to pre-provision, and make
-    // available for claiming later.
-    int64 min = 7 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // A key=value additional configuration to pass to the instance when created.
+  map<string, string> additional = 6 [(google.api.field_behavior) = OPTIONAL];
 
-    // Max from the pooler feature.
-    // Determine the maximum number of instances that needs to be deployed until we
-    // stop pre-provisioning ones in the pool.
-    int64 max = 8 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // Min from the pooler feature.
+  // Determine the minimum number of instances we want to pre-provision, and make
+  // available for claiming later.
+  int64 min = 7 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Max from the pooler feature.
+  // Determine the maximum number of instances that needs to be deployed until we
+  // stop pre-provisioning ones in the pool.
+  int64 max = 8 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 message RetrieveChallengeRequest {
-    // The challenge identifier.
-    string id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier.
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // The request to update a challenge.
 message UpdateChallengeRequest {
-    // The challenge identifier.
-    string id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier.
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The scenario of the challenge. If specified, will updates running instances iif the
-    // old and new hashes differs.
-    optional string scenario = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"base64(zip(.))\""}, (google.api.field_behavior) = OPTIONAL];
-    
-    // If specified, sets the update strategy to adopt in case the challenge has running
-    // instances.
-    // Default to an update in place.
-    optional UpdateStrategy update_strategy = 3;
-    
-    // The timeout after which the janitor will have permission to delete the instances.
-    google.protobuf.Duration timeout = 4 [(google.api.field_behavior) = OPTIONAL];
-    
-    // The date after which the janitor will have permission to delete the instances.
-    google.protobuf.Timestamp until = 5 [(google.api.field_behavior) = OPTIONAL];
+  // The scenario of the challenge. If specified, will updates running instances iif the
+  // old and new hashes differs.
+  optional string scenario = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"base64(zip(.))\""},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
-    google.protobuf.FieldMask update_mask = 6;
+  // If specified, sets the update strategy to adopt in case the challenge has running
+  // instances.
+  // Default to an update in place.
+  optional UpdateStrategy update_strategy = 3;
 
-    // A key=value additional configuration to pass to the instance when created.
-    map<string, string> additional = 7 [(google.api.field_behavior) = OPTIONAL];
+  // The timeout after which the janitor will have permission to delete the instances.
+  google.protobuf.Duration timeout = 4 [(google.api.field_behavior) = OPTIONAL];
 
-    // Min from the pooler feature.
-    // Determine the minimum number of instances we want to pre-provision, and make
-    // available for claiming later.
-    int64 min = 8 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // The date after which the janitor will have permission to delete the instances.
+  google.protobuf.Timestamp until = 5 [(google.api.field_behavior) = OPTIONAL];
 
-    // Max from the pooler feature.
-    // Determine the maximum number of instances that needs to be deployed until we
-    // stop pre-provisioning ones in the pool.
-    int64 max = 9 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  google.protobuf.FieldMask update_mask = 6;
+
+  // A key=value additional configuration to pass to the instance when created.
+  map<string, string> additional = 7 [(google.api.field_behavior) = OPTIONAL];
+
+  // Min from the pooler feature.
+  // Determine the minimum number of instances we want to pre-provision, and make
+  // available for claiming later.
+  int64 min = 8 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
+
+  // Max from the pooler feature.
+  // Determine the maximum number of instances that needs to be deployed until we
+  // stop pre-provisioning ones in the pool.
+  int64 max = 9 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 message DeleteChallengeRequest {
-    // The challenge identifier.
-    string id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier.
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // The challenge object that the chall-manager exposes.
 // Notice it differs from the internal representation, as it also handles
 // filesystem-related information.
 message Challenge {
-    // The challenge identifier.
-    string id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier.
+  string id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The scenario hash, could be usefull to determine when an update is
-    // necessary.
-    string hash = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"md5(base64(<scenario.zip>))\""}, (google.api.field_behavior) = REQUIRED];
+  // The scenario hash, could be usefull to determine when an update is
+  // necessary.
+  string hash = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "\"md5(base64(<scenario.zip>))\""},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The timeout after which the janitor will have permission to delete
-    // the instances.
-    google.protobuf.Duration timeout = 3 [(google.api.field_behavior) = OPTIONAL];
+  // The timeout after which the janitor will have permission to delete
+  // the instances.
+  google.protobuf.Duration timeout = 3 [(google.api.field_behavior) = OPTIONAL];
 
-    // The date after which the janitor will have permission to delete
-    // the instances.
-    google.protobuf.Timestamp until = 4 [(google.api.field_behavior) = OPTIONAL];
+  // The date after which the janitor will have permission to delete
+  // the instances.
+  google.protobuf.Timestamp until = 4 [(google.api.field_behavior) = OPTIONAL];
 
-    // The challenge running instances.
-    repeated instance.Instance instances = 5 [(google.api.field_behavior) = OPTIONAL];
+  // The challenge running instances.
+  repeated instance.Instance instances = 5 [(google.api.field_behavior) = OPTIONAL];
 
-    // A key=value additional configuration to pass to the instance when created.
-    map<string, string> additional = 6 [(google.api.field_behavior) = OPTIONAL];
+  // A key=value additional configuration to pass to the instance when created.
+  map<string, string> additional = 6 [(google.api.field_behavior) = OPTIONAL];
 
-    // Min from the pooler feature.
-    // Determine the minimum number of instances we want to pre-provision, and make
-    // available for claiming later.
-    int64 min = 7 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // Min from the pooler feature.
+  // Determine the minimum number of instances we want to pre-provision, and make
+  // available for claiming later.
+  int64 min = 7 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
-    // Max from the pooler feature.
-    // Determine the maximum number of instances that needs to be deployed until we
-    // stop pre-provisioning ones in the pool.
-    int64 max = 8 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // Max from the pooler feature.
+  // Determine the maximum number of instances that needs to be deployed until we
+  // stop pre-provisioning ones in the pool.
+  int64 max = 8 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 }
 
 // The UpdateStrategy to use in case of a Challenge scenario update with running instances.
 // Default strategy is the update-in-place.
 enum UpdateStrategy {
-    // update_in_place updates the existing state based on the new stack in the scenario.
-    // This update strategy provide high availability with low update costs.
-    update_in_place = 0;
-    
-    // blue_green spins up a second instance of the scenario in parallel and once up,
-    // delete the previous one for players to shift.
-    // This update strategy provide high availability with high update costs due to infra
-    // deduplication.
-    blue_green = 1;
-    
-    // recreate delete the previous instance then spins up a fresh instance of the scenario.
-    // This update strategy provide no availability guarantee with medium update costs due
-    // to intensive create/delete operations. It should be used at a last relief, for
-    // instance if the update is inconsistent and the outcomes are not predictable.
-    recreate = 2;
+  // update_in_place updates the existing state based on the new stack in the scenario.
+  // This update strategy provide high availability with low update costs.
+  update_in_place = 0;
+
+  // blue_green spins up a second instance of the scenario in parallel and once up,
+  // delete the previous one for players to shift.
+  // This update strategy provide high availability with high update costs due to infra
+  // deduplication.
+  blue_green = 1;
+
+  // recreate delete the previous instance then spins up a fresh instance of the scenario.
+  // This update strategy provide no availability guarantee with medium update costs due
+  // to intensive create/delete operations. It should be used at a last relief, for
+  // instance if the update is inconsistent and the outcomes are not predictable.
+  recreate = 2;
 }

--- a/api/v1/common/common.proto
+++ b/api/v1/common/common.proto
@@ -5,23 +5,22 @@ package api.v1.common;
 import "protoc-gen-openapiv2/options/annotations.proto";
 
 option go_package = "github.com/ctfer-io/chall-manager/gen/protos/go/api/v1/common;common";
-
 option (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_swagger) = {
-    info: {
-        title: "Chall-Manager gRPC-gateway generated REST API";
-        version: "v1.0.0";
-        description: "The gRPC-gateway generated REST API OpenAPIv2 swagger.";
-        contact: {
-            name: "CTFer.io";
-            url: "https://ctfer.io";
-            email: "ctfer-io@protonmail.com";
-        };
-        license: {
-            name: "Apache-License 2.0";
-            url: "https://github.com/ctfer-io/chall-manager/blob/main/LICENSE";
-        };
-    };
-    schemes: HTTP;
-    consumes: "application/json";
-    produces: "application/json";
+  info: {
+    title: "Chall-Manager gRPC-gateway generated REST API"
+    version: "v1.0.0"
+    description: "The gRPC-gateway generated REST API OpenAPIv2 swagger."
+    contact: {
+      name: "CTFer.io"
+      url: "https://ctfer.io"
+      email: "ctfer-io@protonmail.com"
+    }
+    license: {
+      name: "Apache-License 2.0"
+      url: "https://github.com/ctfer-io/chall-manager/blob/main/LICENSE"
+    }
+  }
+  schemes: HTTP
+  consumes: "application/json"
+  produces: "application/json"
 };

--- a/api/v1/instance/instance.proto
+++ b/api/v1/instance/instance.proto
@@ -16,119 +16,161 @@ option go_package = "github.com/ctfer-io/chall-manager/api/v1/instance;instance"
 // Through this manager, the instance implements all CRUD operations necessary
 // to handle a lifecycle.
 service InstanceManager {
-    // Spins up a challenge instance, iif the challenge is registered
-    // and no instance is yet running.
-    rpc CreateInstance(CreateInstanceRequest) returns (Instance) {
-        option(google.api.http) = {
-            post: "/api/v1/instance"
-            body: "*"
-        };
-    }
+  // Spins up a challenge instance, iif the challenge is registered
+  // and no instance is yet running.
+  rpc CreateInstance(CreateInstanceRequest) returns (Instance) {
+    option (google.api.http) = {
+      post: "/api/v1/instance"
+      body: "*"
+    };
+  }
 
-    // Once created, you can retrieve the instance information.
-    // If it has not been created yet, returns an error. 
-    rpc RetrieveInstance(RetrieveInstanceRequest) returns (Instance) {
-        option(google.api.http) = {
-            get: "/api/v1/instance/{challenge_id}/{source_id}"
-        };
-    }
+  // Once created, you can retrieve the instance information.
+  // If it has not been created yet, returns an error.
+  rpc RetrieveInstance(RetrieveInstanceRequest) returns (Instance) {
+    option (google.api.http) = {get: "/api/v1/instance/{challenge_id}/{source_id}"};
+  }
 
-    // Query all instances that matches the request parameters.
-    // Especially usefull to query all the instances of a source_id.
-    rpc QueryInstance(QueryInstanceRequest) returns (stream Instance) {
-        option(google.api.http) = {
-            get: "/api/v1/instance"
-        };
-    }
+  // Query all instances that matches the request parameters.
+  // Especially usefull to query all the instances of a source_id.
+  rpc QueryInstance(QueryInstanceRequest) returns (stream Instance) {
+    option (google.api.http) = {get: "/api/v1/instance"};
+  }
 
-    // Once an instance is spinned up, it will have a lifetime.
-    // Passed it, it will exprie i.e. will be deleted as soon as possible
-    // by the chall-manager-janitor.
-    // To increase this lifetime, a player can ask to renew it. This will
-    // set the until date to the request time more the challenge timeout. 
-    rpc RenewInstance(RenewInstanceRequest) returns(Instance) {
-        option(google.api.http) = {
-            patch: "/api/v1/instance/{challenge_id}/{source_id}"
-            body: "*"
-        };
-    }
+  // Once an instance is spinned up, it will have a lifetime.
+  // Passed it, it will exprie i.e. will be deleted as soon as possible
+  // by the chall-manager-janitor.
+  // To increase this lifetime, a player can ask to renew it. This will
+  // set the until date to the request time more the challenge timeout.
+  rpc RenewInstance(RenewInstanceRequest) returns (Instance) {
+    option (google.api.http) = {
+      patch: "/api/v1/instance/{challenge_id}/{source_id}"
+      body: "*"
+    };
+  }
 
-    // After completion, the challenge instance is no longer required.
-    // This spins down the instance and removes if from filesystem.
-    rpc DeleteInstance(DeleteInstanceRequest) returns (google.protobuf.Empty) {
-        option(google.api.http) = {
-            delete: "/api/v1/instance/{challenge_id}/{source_id}"
-        };
-    }
+  // After completion, the challenge instance is no longer required.
+  // This spins down the instance and removes if from filesystem.
+  rpc DeleteInstance(DeleteInstanceRequest) returns (google.protobuf.Empty) {
+    option (google.api.http) = {delete: "/api/v1/instance/{challenge_id}/{source_id}"};
+  }
 }
 
 message CreateInstanceRequest {
-    // The challenge identifier
-    string challenge_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier
+  string challenge_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The source (user/team) identifier.
-    string source_id = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The source (user/team) identifier.
+  string source_id = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // A key=value additional configuration to pass to the instance when created.
-    map<string, string> additional = 3 [(google.api.field_behavior) = OPTIONAL];
+  // A key=value additional configuration to pass to the instance when created.
+  map<string, string> additional = 3 [(google.api.field_behavior) = OPTIONAL];
 }
 
 message RetrieveInstanceRequest {
-    // The challenge identifier
-    string challenge_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier
+  string challenge_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The source (user/team) identifier.
-    string source_id = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The source (user/team) identifier.
+  string source_id = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message QueryInstanceRequest {
-    // The source (user/team) identifier.
-    string source_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The source (user/team) identifier.
+  string source_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message RenewInstanceRequest {
-    // The challenge identifier
-    string challenge_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier
+  string challenge_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The source (user/team) identifier.
-    string source_id = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The source (user/team) identifier.
+  string source_id = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 message DeleteInstanceRequest {
-    // The challenge identifier
-    string challenge_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier
+  string challenge_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The source (user/team) identifier.
-    string source_id = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The source (user/team) identifier.
+  string source_id = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 }
 
 // The challenge instance object that the chall-manager exposes.
 // Notice it differs from the internal representation, as it handles
 // filesystem-related information.
 message Instance {
-    // The challenge identifier
-    string challenge_id = 1 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The challenge identifier
+  string challenge_id = 1 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The source (user/team) identifier.
-    string source_id = 2 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The source (user/team) identifier.
+  string source_id = 2 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The time since when the instance is running.
-    google.protobuf.Timestamp since = 3 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The time since when the instance is running.
+  google.protobuf.Timestamp since = 3 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The last time the instance has been renewed.
-    google.protobuf.Timestamp last_renew = 4 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The last time the instance has been renewed.
+  google.protobuf.Timestamp last_renew = 4 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // The time the instance will "die" i.e. be destroyed by the janitor.
-    optional google.protobuf.Timestamp until = 5 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // The time the instance will "die" i.e. be destroyed by the janitor.
+  optional google.protobuf.Timestamp until = 5 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
-    // The connection information that is given to the players in order
-    // to reach their instance.
-    string connection_info = 6 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = REQUIRED];
+  // The connection information that is given to the players in order
+  // to reach their instance.
+  string connection_info = 6 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = REQUIRED
+  ];
 
-    // If specified, the flag that validates the challenge instance.
-    // This avoids shareflag, but don't block sharing solving strategy/write-up.
-    optional string flag = 7 [(grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"}, (google.api.field_behavior) = OPTIONAL];
+  // If specified, the flag that validates the challenge instance.
+  // This avoids shareflag, but don't block sharing solving strategy/write-up.
+  optional string flag = 7 [
+    (grpc.gateway.protoc_gen_openapiv2.options.openapiv2_field) = {example: "1"},
+    (google.api.field_behavior) = OPTIONAL
+  ];
 
-    // A key=value additional configuration to pass to the instance when created.
-    map<string, string> additional = 8 [(google.api.field_behavior) = OPTIONAL];
+  // A key=value additional configuration to pass to the instance when created.
+  map<string, string> additional = 8 [(google.api.field_behavior) = OPTIONAL];
 }

--- a/buf.yaml
+++ b/buf.yaml
@@ -1,14 +1,13 @@
 version: v2
-name: buf.build/blainsmith/grpc-gateway-openapi-example
+modules:
+  - path: .
+    name: buf.build/ctfer-io/chall-manager
 deps:
   - buf.build/googleapis/googleapis:c20f392efc5c9e4f16b37002996607c4cdde4dd3
   - buf.build/grpc-ecosystem/grpc-gateway:b135f1861a571080ea22cfbd440c76c58741f15b
 lint:
   use:
-    - DEFAULT
-  except:
-    - FIELD_NOT_REQUIRED
-    - PACKAGE_NO_IMPORT_CYCLE
+    - MINIMAL
   disallow_comment_ignores: true
 breaking:
   use:

--- a/go.work.sum
+++ b/go.work.sum
@@ -532,8 +532,11 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.25.0
 github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.26.0/go.mod h1:2bIszWvQRlJVmJLiuLhukLImRjKPcYdzzsx6darK02A=
 github.com/KimMachineGun/automemlimit v0.5.0/go.mod h1:di3GCKiu9Y+1fs92erCbUvKzPkNyViN3mA0vti/ykEQ=
 github.com/MakeNowJust/heredoc v1.0.0/go.mod h1:mG5amYoWBHf8vpLOuehzbGGw0EHxpZZ6lCpQ4fNJ8LE=
+github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
+github.com/Masterminds/sprig/v3 v3.2.1 h1:n6EPaDyLSvCEa3frruQvAiHuNp2dhBlMSmkEr+HuzGc=
 github.com/Masterminds/sprig/v3 v3.2.1/go.mod h1:UoaO7Yp8KlPnJIYWTFkMaqPUYKTfGFPhxNuwnnxkKlk=
 github.com/Microsoft/cosesign1go v1.1.0/go.mod h1:o+sw7nhlGE6twhfjXQDWmBJO8zmfQXEmCcXEi3zha8I=
 github.com/Microsoft/cosesign1go v1.2.0/go.mod h1:1La/HcGw19rRLhPW0S6u55K6LKfti+GQSgGCtrfhVe8=
@@ -664,8 +667,11 @@ github.com/charmbracelet/x/ansi v0.4.2/go.mod h1:dk73KoMTT5AX5BsX0KrqhsTqAnhZZoC
 github.com/charmbracelet/x/exp/golden v0.0.0-20240806155701-69247e0abc2a/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/exp/golden v0.0.0-20240815200342-61de596daa2b/go.mod h1:wDlXFlCrmJ8J+swcL/MnGUuYnqgQdW9rhSD61oNMb6U=
 github.com/charmbracelet/x/term v0.2.0/go.mod h1:GVxgxAbjUrmpvIINHIQnJJKpMlHiZ4cktEQCN6GWyF0=
+github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1/go.mod h1:JLbx6lG2kDbNRFnfkgvh4eRJRPX1QCoOIWomwysCBrQ=
+github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/readline v1.5.1/go.mod h1:Eh+b79XXUwfKfcPLepksvw2tcLE/Ct21YObkaSkeBlk=
+github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/chzyer/test v1.0.0/go.mod h1:2JlltgoNkt4TW/z9V/IzDdFaMTM2JPIi26O1pF38GC8=
 github.com/cilium/ebpf v0.11.0/go.mod h1:WE7CZAnqOL2RouJ4f1uyNhqr2P4CCvXFIqdRDUgWsVs=
 github.com/cilium/ebpf v0.16.0/go.mod h1:L7u2Blt2jMM/vLAVgjxluxtBKlz3/GWjB0dMOEngfwE=
@@ -918,6 +924,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vb
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.0.1/go.mod h1:lXGCsh6c22WGtjr+qGHj1otzZpV/1kwTMAqkwZsnWRU=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0/go.mod h1:XKMd7iuf/RGPSMJ/U4HP0zS2Z9Fh8Ps9a+6X26m/tmI=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0 h1:Ovs26xHkKqVztRpIrF/92BcuyuQ/YW4NSIpoGtfXNho=
+github.com/grpc-ecosystem/grpc-gateway v1.9.5 h1:UImYN5qQ8tuGpGE16ZmjvcTtTw24zw1QAp/SlnNrZhI=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0 h1:gmcG1KaJ57LophUzW0Hy8NmPhnMZb4M0+kPpLofRdBo=
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.16.0/go.mod h1:YN5jB8ie0yfIUg6VvR9Kz84aCaG7AsGZnLjhHbUqwPg=
@@ -972,6 +979,7 @@ github.com/hinshun/vt10x v0.0.0-20220119200601-820417d04eec/go.mod h1:Q48J4R4Dvx
 github.com/hinshun/vt10x v0.0.0-20220301184237-5011da428d02/go.mod h1:Q48J4R4DvxnHolD5P8pOtXigYlRuPLGl6moFx3ulM68=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/huandu/xstrings v1.3.1/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
 github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
 github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
 github.com/iancoleman/strcase v0.3.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=
@@ -980,6 +988,7 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20240312041847-bd984b5ce465/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/ianlancetaylor/demangle v0.0.0-20250417193237-f615e6bd150b/go.mod h1:gx7rwoVhcfuVKG5uya9Hs3Sxj7EIvldVofAWIUtGouw=
 github.com/ijc/Gotty v0.0.0-20170406111628-a8b993ba6abd/go.mod h1:3LVOLeyx9XVvwPgrt2be44XgSqndprz1G18rSk8KD84=
+github.com/imdario/mergo v0.3.11 h1:3tnifQM4i+fbajXKBHXWEH+KvNHqojZ778UH75j3bGA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
@@ -1187,6 +1196,7 @@ github.com/pulumi/pulumi-yaml v1.11.2/go.mod h1:RdXRBupRGGAD1kbYNG1V1h6pyFnXisvQ
 github.com/pulumi/pulumi-yaml v1.12.0/go.mod h1:EhZd1XDfuLa15O51qVVE16U6r8ldK9mLIBclqWCX27Y=
 github.com/pulumi/pulumi/pkg/v3 v3.131.0/go.mod h1:+Cy9VMptNdrhGMcYWg3ZqzWlih+hyWoGOImRSoPNs8o=
 github.com/pulumi/pulumi/pkg/v3 v3.137.0/go.mod h1:ZQXJUTysDwq/mtilutRBKguH6DI+3b2WgNcOrs0whJ0=
+github.com/pulumi/pulumi/pkg/v3 v3.154.0/go.mod h1:IS+Yqg2NnvjdkBR7+tpBfzIKiCAHO/8Cwcg9UZ4YoVY=
 github.com/pulumi/pulumi/sdk/v3 v3.127.0/go.mod h1:p1U24en3zt51agx+WlNboSOV8eLlPWYAkxMzVEXKbnY=
 github.com/pulumi/pulumi/sdk/v3 v3.131.0/go.mod h1:J5kQEX8v87aeUhk6NdQXnjCo1DbiOnOiL3Sf2DuDda8=
 github.com/pulumi/pulumi/sdk/v3 v3.132.0/go.mod h1:J5kQEX8v87aeUhk6NdQXnjCo1DbiOnOiL3Sf2DuDda8=
@@ -1195,7 +1205,9 @@ github.com/pulumi/pulumi/sdk/v3 v3.137.0/go.mod h1:PvKsX88co8XuwuPdzolMvew5lZV+4
 github.com/pulumi/pulumi/sdk/v3 v3.143.0/go.mod h1:OFpZabILGxrFqzcABFpMCksrHGVp4ymRM2BkKjlazDY=
 github.com/pulumi/pulumi/sdk/v3 v3.146.0/go.mod h1:4iCUMfpr1Kj5/YzY13/Ef2GPKFJy5Kk4hCe2dEXRVoc=
 github.com/pulumi/pulumi/sdk/v3 v3.153.1/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=
+github.com/pulumi/pulumi/sdk/v3 v3.154.0/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=
 github.com/pulumi/pulumi/sdk/v3 v3.156.0/go.mod h1:+WC9aIDo8fMgd2g0jCHuZU2S/VYNLRAZ3QXt6YVgwaA=
+github.com/pulumi/pulumi/sdk/v3 v3.166.0/go.mod h1:GAaHrdv3kWJHbzkFFFflGbTBQXUYu6SF1ZCo+O9jo44=
 github.com/rabbitmq/amqp091-go v1.9.0/go.mod h1:+jPrT9iY2eLjRaMSRHUhc3z14E/l85kv/f+6luSD3pc=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
@@ -1218,6 +1230,7 @@ github.com/segmentio/asm v1.1.3/go.mod h1:Ld3L4ZXGNcSLRg4JBsZ3//1+f/TjYl0Mzen/DQ
 github.com/segmentio/encoding v0.3.5/go.mod h1:n0JeuIqEQrQoPDGsjo8UNd1iA0U8d8+oHAA4E3G3OxM=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shirou/gopsutil/v3 v3.22.3/go.mod h1:D01hZJ4pVHPpCTZ3m3T2+wDF2YAGfd+H4ifUguaQzHM=
+github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=
 github.com/shopspring/decimal v1.2.0/go.mod h1:DKyhrW/HYNuLGql+MJL6WCR6knT2jwCFRcu2hWCYk4o=
 github.com/shurcooL/go-goon v0.0.0-20210110234559-7585751d9a17/go.mod h1:N5mDOmsrJOB+vfqUK+7DmDyjhSLIIBnXo9lvZJj3MWQ=
 github.com/shurcooL/httpfs v0.0.0-20190707220628-8d4bc4ba7749/go.mod h1:ZY1cvUeJuFPAdZ/B6v7RHavJWZn2YPVFQ1OSXhCGOkg=
@@ -1230,6 +1243,7 @@ github.com/spf13/afero v1.9.5/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/
 github.com/spf13/afero v1.10.0/go.mod h1:UBogFpq8E9Hx+xc5CNTTEpTnuHVmXDwZcZcE1eb/UhQ=
 github.com/spf13/afero v1.11.0/go.mod h1:GH9Y3pIexgf1MTIWtNGyogA5MwRIDXGUr+hbWNoBjkY=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
+github.com/spf13/cast v1.5.0/go.mod h1:SpXXQ5YoyJw6s3/6cMTQuxvgRl3PCJiyaX9p6b155UU=
 github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=
 github.com/spf13/pflag v1.0.2/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
@@ -1237,6 +1251,7 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/viper v1.18.2/go.mod h1:EKmWIqdnk5lOcmR72yw6hS+8OPYcwD0jteitLMVB+yk=
 github.com/spiffe/go-spiffe/v2 v2.5.0/go.mod h1:P+NxobPc6wXhVtINNtFjNWGBTreew1GBUCwT2wPmb7g=
 github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6/go.mod h1:39R/xuhNgVhi+K0/zst4TLrJrVmbm6LVgl4A0+ZFS5M=
+github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
@@ -1350,6 +1365,7 @@ go.opentelemetry.io/otel/sdk v1.24.0/go.mod h1:KVrIYw6tEubO9E96HQpcmpTKDVn9gdv35
 go.opentelemetry.io/otel/sdk v1.29.0/go.mod h1:pM8Dx5WKnvxLCb+8lG1PRNIDxu9g9b9g59Qr7hfAAok=
 go.opentelemetry.io/otel/sdk v1.32.0/go.mod h1:LqgegDBjKMmb2GC6/PrTnteJG39I8/vJCAP9LlJXEjU=
 go.opentelemetry.io/otel/sdk v1.34.0/go.mod h1:0e/pNiaMAqaykJGKbi+tSjWfNNHMTxoC9qANsCzbyxU=
+go.opentelemetry.io/otel/sdk/log/logtest v0.0.0-20250521073539-a85ae98dcedc/go.mod h1:TY/N/FT7dmFrP/r5ym3g0yysP1DefqGpAZr4f82P0dE=
 go.opentelemetry.io/otel/sdk/metric v1.31.0/go.mod h1:CRInTMVvNhUKgSAMbKyTMxqOBC0zgyxzW55lZzX43Y8=
 go.opentelemetry.io/otel/sdk/metric v1.32.0/go.mod h1:PWeZlq0zt9YkYAp3gjKZ0eicRYvOh1Gd+X99x6GHpCQ=
 go.opentelemetry.io/otel/sdk/metric v1.34.0/go.mod h1:jQ/r8Ze28zRKoNRdkjCZxfs6YvBTG1+YIqyFVFYec5w=
@@ -1867,6 +1883,7 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20250303144028-a0af3efb3deb/go.
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250324211829-b45e905df463/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250409194420-de1ac958c67a/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20250428153025-10db94c68c34/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
+google.golang.org/genproto/googleapis/rpc v0.0.0-20250512202823-5a2f75b736a9/go.mod h1:qQ0YXyHHx3XkvlzUtpXDkS29lDSafHMZBAZDc03LQ3A=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.28.0/go.mod h1:rpkK4SK4GF4Ach/+MFLZUBavHOvF2JJB5uozKKal+60=


### PR DESCRIPTION
This PR adds buf linting for `.proto`files, with `MINIMAL` rules. I avoid `STANDARD` due to various rules I don't want to consider especially in naming (see `buf config ls-lint-rules` output).

It also publish the protos to the BSR (Buf Schema Registry) on releases.

To test things I [manually pushed protos](https://buf.build/ctfer-io/chall-manager).

Resolves #741 