### PR TITLE
Add missing netpol to allow ingress traffic from cmj to cm, and fix pod labels of cmj

### DIFF
--- a/deploy/services/parts/chall-manager-janitor.go
+++ b/deploy/services/parts/chall-manager-janitor.go
@@ -318,13 +318,11 @@ func (cmj *ChallManagerJanitor) provision(ctx *pulumi.Context, args *ChallManage
 func (cmj *ChallManagerJanitor) outputs(ctx *pulumi.Context, args *ChallManagerJanitorArgs) error {
 	switch args.Mode {
 	case JanitorModeCron:
-		cmj.PodLabels = cmj.cjob.Spec.JobTemplate().Metadata().Labels()
+		cmj.PodLabels = cmj.cjob.Spec.JobTemplate().Spec().Template().Metadata().Labels()
 
 	case JanitorModeTicker:
-		cmj.PodLabels = cmj.dep.Metadata.Labels()
+		cmj.PodLabels = cmj.dep.Spec.Template().Metadata().Labels()
 	}
-
-	cmj.PodLabels = cmj.cjob.Spec.JobTemplate().Metadata().Labels()
 
 	return ctx.RegisterResourceOutputs(cmj, pulumi.Map{
 		"podLabels": cmj.PodLabels,


### PR DESCRIPTION
Resolves #757 

It also fixes the pod labels, as I discovered during triage that they were invalid (hence targeting every pod within the namespace...).
