### PR TITLE
Improve management of external services

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -105,6 +105,11 @@ jobs:
               .
           docker push localhost:5000/ctferio/chall-manager-janitor:${{ github.sha }}
 
+      - name: Load Docker images
+        run: |
+          docker pull bitnami/etcd:3.5.16-debian-12-r0 && docker tag $_ localhost:5000/$_ && docker push $_
+          docker pull library/busybox:1.28             && docker tag $_ localhost:5000/$_ && docker push $_
+
       - name: Install Pulumi
         uses: pulumi/actions@df5a93ad715135263c732ba288301bd044c383c0 # v6.3.0
       - name: Prepare environment

--- a/api/v1/challenge/create.go
+++ b/api/v1/challenge/create.go
@@ -36,7 +36,7 @@ func (store *Store) CreateChallenge(ctx context.Context, req *CreateChallengeReq
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -51,7 +51,7 @@ func (store *Store) CreateChallenge(ctx context.Context, req *CreateChallengeReq
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock RW challenge
-	clock, err := common.LockChallenge(req.Id)
+	clock, err := common.LockChallenge(ctx, req.Id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(

--- a/api/v1/challenge/delete.go
+++ b/api/v1/challenge/delete.go
@@ -27,7 +27,7 @@ func (store *Store) DeleteChallenge(ctx context.Context, req *DeleteChallengeReq
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -42,7 +42,7 @@ func (store *Store) DeleteChallenge(ctx context.Context, req *DeleteChallengeReq
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock RW challenge
-	clock, err := common.LockChallenge(req.Id)
+	clock, err := common.LockChallenge(ctx, req.Id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(
@@ -120,7 +120,7 @@ func (store *Store) DeleteChallenge(ctx context.Context, req *DeleteChallengeReq
 			defer work.Done()
 
 			// 6.a. Lock RW instance
-			ilock, err := common.LockInstance(req.Id, identity)
+			ilock, err := common.LockInstance(ctx, req.Id, identity)
 			if err != nil {
 				cerr <- err
 				relock.Done() // release to avoid dead-lock

--- a/api/v1/challenge/query.go
+++ b/api/v1/challenge/query.go
@@ -25,7 +25,7 @@ func (store *Store) QueryChallenge(_ *emptypb.Empty, server ChallengeStore_Query
 
 	// 1. Lock RW TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -67,7 +67,7 @@ func (store *Store) QueryChallenge(_ *emptypb.Empty, server ChallengeStore_Query
 			ctx = global.WithChallengeID(ctx, id)
 
 			// 4.a. Lock R challenge
-			clock, err := common.LockChallenge(id)
+			clock, err := common.LockChallenge(ctx, id)
 			if err != nil {
 				cerr <- err
 				relock.Done() // release to avoid dead-lock

--- a/api/v1/challenge/retrieve.go
+++ b/api/v1/challenge/retrieve.go
@@ -25,7 +25,7 @@ func (store *Store) RetrieveChallenge(ctx context.Context, req *RetrieveChalleng
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -40,7 +40,7 @@ func (store *Store) RetrieveChallenge(ctx context.Context, req *RetrieveChalleng
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock R challenge
-	clock, err := common.LockChallenge(req.Id)
+	clock, err := common.LockChallenge(ctx, req.Id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(

--- a/api/v1/challenge/update.go
+++ b/api/v1/challenge/update.go
@@ -42,7 +42,7 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -58,7 +58,7 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 
 	// 2. Lock RW challenge
 	span.AddEvent("lock challenge")
-	clock, err := common.LockChallenge(req.Id)
+	clock, err := common.LockChallenge(ctx, req.Id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(
@@ -222,7 +222,7 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 			ctx = global.WithIdentity(ctx, identity)
 
 			// 8.a. Lock RW instance
-			ilock, err := common.LockInstance(req.Id, identity)
+			ilock, err := common.LockInstance(ctx, req.Id, identity)
 			if err != nil {
 				cerr <- err
 				return

--- a/api/v1/common/locks.go
+++ b/api/v1/common/locks.go
@@ -11,16 +11,16 @@ import (
 	"github.com/ctfer-io/chall-manager/pkg/lock"
 )
 
-func LockTOTW() (lock.RWLock, error) {
-	return lock.NewRWLock("totw")
+func LockTOTW(ctx context.Context) (lock.RWLock, error) {
+	return lock.NewRWLock(ctx, "totw")
 }
 
-func LockChallenge(challengeID string) (lock.RWLock, error) {
-	return lock.NewRWLock(filepath.Join("chall", fs.Hash(challengeID)))
+func LockChallenge(ctx context.Context, challengeID string) (lock.RWLock, error) {
+	return lock.NewRWLock(ctx, filepath.Join("chall", fs.Hash(challengeID)))
 }
 
-func LockInstance(challengeID, identity string) (lock.RWLock, error) {
-	return lock.NewRWLock(filepath.Join("chall", fs.Hash(challengeID), "src", fs.Hash(identity)))
+func LockInstance(ctx context.Context, challengeID, identity string) (lock.RWLock, error) {
+	return lock.NewRWLock(ctx, filepath.Join("chall", fs.Hash(challengeID), "src", fs.Hash(identity)))
 }
 
 // LClose is a helper that logs any error during the lock close call.

--- a/api/v1/instance/create.go
+++ b/api/v1/instance/create.go
@@ -27,7 +27,7 @@ func (man *Manager) CreateInstance(ctx context.Context, req *CreateInstanceReque
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -42,7 +42,7 @@ func (man *Manager) CreateInstance(ctx context.Context, req *CreateInstanceReque
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock RW challenge
-	clock, err := common.LockChallenge(req.ChallengeId)
+	clock, err := common.LockChallenge(ctx, req.ChallengeId)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(
@@ -158,7 +158,7 @@ func (man *Manager) CreateInstance(ctx context.Context, req *CreateInstanceReque
 
 		// Lock RW instance
 		ctx = global.WithSourceID(ctx, req.SourceId)
-		ilock, err := common.LockInstance(req.ChallengeId, claimed)
+		ilock, err := common.LockInstance(ctx, req.ChallengeId, claimed)
 		if err != nil {
 			err := &errs.ErrInternal{Sub: err}
 			logger.Error(ctx, "build instance lock",

--- a/api/v1/instance/delete.go
+++ b/api/v1/instance/delete.go
@@ -26,7 +26,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -41,7 +41,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock RW challenge
-	clock, err := common.LockChallenge(req.ChallengeId)
+	clock, err := common.LockChallenge(ctx, req.ChallengeId)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(
@@ -108,7 +108,7 @@ func (man *Manager) DeleteInstance(ctx context.Context, req *DeleteInstanceReque
 	}
 
 	ctx = global.WithIdentity(ctx, id)
-	ilock, err := common.LockInstance(req.ChallengeId, id)
+	ilock, err := common.LockInstance(ctx, req.ChallengeId, id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock",

--- a/api/v1/instance/query.go
+++ b/api/v1/instance/query.go
@@ -22,7 +22,7 @@ func (man *Manager) QueryInstance(req *QueryInstanceRequest, server InstanceMana
 
 	// 1. Lock RW TOTW -> R should be sufficient, but we want this query to be as fast as possible
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -65,7 +65,7 @@ func (man *Manager) QueryInstance(req *QueryInstanceRequest, server InstanceMana
 			defer work.Done()
 
 			// 4.a. Lock R challenge
-			clock, err := common.LockChallenge(challengeID)
+			clock, err := common.LockChallenge(ctx, challengeID)
 			if err != nil {
 				cerr <- err
 				relock.Done() // release to avoid dead-lock

--- a/api/v1/instance/renew.go
+++ b/api/v1/instance/renew.go
@@ -25,7 +25,7 @@ func (man *Manager) RenewInstance(ctx context.Context, req *RenewInstanceRequest
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -40,7 +40,7 @@ func (man *Manager) RenewInstance(ctx context.Context, req *RenewInstanceRequest
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock R challenge
-	clock, err := common.LockChallenge(req.ChallengeId)
+	clock, err := common.LockChallenge(ctx, req.ChallengeId)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(
@@ -96,7 +96,7 @@ func (man *Manager) RenewInstance(ctx context.Context, req *RenewInstanceRequest
 	// 5. Lock RW instance
 	ctx = global.WithSourceID(ctx, req.SourceId)
 	ctx = global.WithIdentity(ctx, id)
-	ilock, err := common.LockInstance(req.ChallengeId, id)
+	ilock, err := common.LockInstance(ctx, req.ChallengeId, id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(err))

--- a/api/v1/instance/retrieve.go
+++ b/api/v1/instance/retrieve.go
@@ -22,7 +22,7 @@ func (man *Manager) RetrieveInstance(ctx context.Context, req *RetrieveInstanceR
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -37,7 +37,7 @@ func (man *Manager) RetrieveInstance(ctx context.Context, req *RetrieveInstanceR
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock R challenge
-	clock, err := common.LockChallenge(req.ChallengeId)
+	clock, err := common.LockChallenge(ctx, req.ChallengeId)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(
@@ -93,7 +93,7 @@ func (man *Manager) RetrieveInstance(ctx context.Context, req *RetrieveInstanceR
 	// 4. Lock R instance
 	ctx = global.WithSourceID(ctx, req.SourceId)
 	ctx = global.WithIdentity(ctx, id)
-	ilock, err := common.LockInstance(req.ChallengeId, id)
+	ilock, err := common.LockInstance(ctx, req.ChallengeId, id)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(

--- a/api/v1/instance/spin.go
+++ b/api/v1/instance/spin.go
@@ -36,7 +36,7 @@ func SpinUp(ctx context.Context, challengeID string) {
 
 	// 1. Lock R TOTW
 	span.AddEvent("lock TOTW")
-	totw, err := common.LockTOTW()
+	totw, err := common.LockTOTW(ctx)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build TOTW lock", zap.Error(err))
@@ -51,7 +51,7 @@ func SpinUp(ctx context.Context, challengeID string) {
 	span.AddEvent("locked TOTW")
 
 	// 2. Lock R challenge
-	clock, err := common.LockChallenge(challengeID)
+	clock, err := common.LockChallenge(ctx, challengeID)
 	if err != nil {
 		err := &errs.ErrInternal{Sub: err}
 		logger.Error(ctx, "build challenge lock", zap.Error(multierr.Combine(

--- a/cmd/chall-manager/main.go
+++ b/cmd/chall-manager/main.go
@@ -252,5 +252,12 @@ func run(c *cli.Context) error {
 	stop()
 	logger.Info(ctx, "shutting down gracefully")
 
+	ctx = context.WithoutCancel(ctx)
+	if err := global.GetEtcdManager().Close(ctx); err != nil {
+		logger.Error(ctx, "closing connection to etcd",
+			zap.Error(err),
+		)
+	}
+
 	return nil
 }

--- a/deploy/Pulumi.yaml
+++ b/deploy/Pulumi.yaml
@@ -20,7 +20,7 @@ config:
     default: info
   etcd.replicas:
     type: integer
-    description: The etcd amount of replicas in the cluster. If none set, will deploy Chall-Manager in `lock=local` (Optional)
+    description: The etcd numer of replicas in the cluster. If none set, will deploy Chall-Manager in `lock=local`. Could be alternatively set with `etcd-replicas` (Optional)
     default: 0
   replicas:
     type: integer

--- a/deploy/integration/cluster_test.go
+++ b/deploy/integration/cluster_test.go
@@ -26,7 +26,7 @@ func Test_I_Cluster(t *testing.T) {
 			"registry":         os.Getenv("REGISTRY"),
 			"tag":              os.Getenv("TAG"),
 			"romeo-claim-name": os.Getenv("ROMEO_CLAIM_NAME"),
-			"pvc-access-mode":  "ReadWriteOnce", // run 1 replica on 1 node, on need for RWX
+			"pvc-access-mode":  "ReadWriteOnce", // run 1 replica on 1 node, no need for RWX
 			"replicas":         "1",             // no need to replicate, we test proper deployments
 			"etcd-replicas":    "1",             // no need to replicate, we test proper deployment
 		},

--- a/deploy/integration/cluster_test.go
+++ b/deploy/integration/cluster_test.go
@@ -1,0 +1,34 @@
+package integration_test
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/pulumi/pulumi/pkg/v3/testing/integration"
+)
+
+func Test_I_Cluster(t *testing.T) {
+	// This is a smoke test for a production-grade deployment.
+	// We do not deploy replicas to avoid overloading CI, and only
+	// require to check it could be deployed as a cluster.
+	//
+	// We do not run extra tests as we expect no impact on features.
+
+	pwd, _ := os.Getwd()
+	integration.ProgramTest(t, &integration.ProgramTestOptions{
+		Quick:       true,
+		SkipRefresh: true,
+		Dir:         path.Join(pwd, ".."),
+		StackName:   stackName(t.Name()),
+		Config: map[string]string{
+			"namespace":        os.Getenv("NAMESPACE"),
+			"registry":         os.Getenv("REGISTRY"),
+			"tag":              os.Getenv("TAG"),
+			"romeo-claim-name": os.Getenv("ROMEO_CLAIM_NAME"),
+			"pvc-access-mode":  "ReadWriteOnce", // run 1 replica on 1 node, on need for RWX
+			"replicas":         "1",             // no need to replicate, we test proper deployments
+			"etcd-replicas":    "1",             // no need to replicate, we test proper deployment
+		},
+	})
+}

--- a/deploy/main.go
+++ b/deploy/main.go
@@ -126,6 +126,11 @@ func loadConfig(ctx *pulumi.Context) *Config {
 	if err := cfg.TryObject("etcd", &etcdC); err == nil && etcdC.Replicas != 0 {
 		c.Etcd = &etcdC
 	}
+	if etcdRecplias := cfg.GetInt("etcd-replicas"); etcdRecplias != 0 {
+		c.Etcd = &EtcdConfig{
+			Replicas: etcdRecplias,
+		}
+	}
 
 	var janitorC JanitorConfig
 	if err := cfg.TryObject("janitor", &janitorC); err == nil {

--- a/deploy/services/chall-manager.go
+++ b/deploy/services/chall-manager.go
@@ -466,7 +466,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 	if args.EtcdReplicas != nil {
 		cm.cmToEtcd, err = netwv1.NewNetworkPolicy(ctx, "cm-to-etcd", &netwv1.NetworkPolicyArgs{
 			Metadata: metav1.ObjectMetaArgs{
-				Namespace: args.Namespace,
+				Namespace: namespace,
 				Labels: pulumi.StringMap{
 					"app.kubernetes.io/components": pulumi.String("chall-manager"),
 					"app.kubernetes.io/part-of":    pulumi.String("chall-manager"),
@@ -486,7 +486,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 							netwv1.NetworkPolicyPeerArgs{
 								NamespaceSelector: metav1.LabelSelectorArgs{
 									MatchLabels: pulumi.StringMap{
-										"kubernetes.io/metadata.name": args.Namespace,
+										"kubernetes.io/metadata.name": namespace,
 									},
 								},
 								PodSelector: metav1.LabelSelectorArgs{
@@ -516,7 +516,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 	// => NetworkPolicy from chall-manager-janitor to chall-manager
 	cm.cmjToCm, err = netwv1.NewNetworkPolicy(ctx, "cmj-to-cm", &netwv1.NetworkPolicyArgs{
 		Metadata: metav1.ObjectMetaArgs{
-			Namespace: args.Namespace,
+			Namespace: namespace,
 			Labels: pulumi.StringMap{
 				"app.kubernetes.io/components": pulumi.String("chall-manager"),
 				"app.kubernetes.io/part-of":    pulumi.String("chall-manager"),
@@ -536,7 +536,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 						netwv1.NetworkPolicyPeerArgs{
 							NamespaceSelector: metav1.LabelSelectorArgs{
 								MatchLabels: pulumi.StringMap{
-									"kubernetes.io/metadata.name": args.Namespace,
+									"kubernetes.io/metadata.name": namespace,
 								},
 							},
 							PodSelector: metav1.LabelSelectorArgs{
@@ -564,7 +564,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 
 	cm.cmFromCmj, err = netwv1.NewNetworkPolicy(ctx, "cm-from-cmj", &netwv1.NetworkPolicyArgs{
 		Metadata: metav1.ObjectMetaArgs{
-			Namespace: args.Namespace,
+			Namespace: namespace,
 			Labels: pulumi.StringMap{
 				"app.kubernetes.io/components": pulumi.String("chall-manager"),
 				"app.kubernetes.io/part-of":    pulumi.String("chall-manager"),
@@ -584,7 +584,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 						netwv1.NetworkPolicyPeerArgs{
 							NamespaceSelector: metav1.LabelSelectorArgs{
 								MatchLabels: pulumi.StringMap{
-									"kubernetes.io/metadata.name": args.Namespace,
+									"kubernetes.io/metadata.name": namespace,
 								},
 							},
 							PodSelector: metav1.LabelSelectorArgs{

--- a/deploy/services/parts/chall-manager.go
+++ b/deploy/services/parts/chall-manager.go
@@ -464,7 +464,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 
 		envs = append(envs,
 			corev1.EnvVarArgs{
-				Name:  pulumi.String("LOCK_ETCD_ENDPOINTS"),
+				Name:  pulumi.String("LOCK_ETCD_ENDPOINT"),
 				Value: args.Etcd.Endpoint,
 			},
 			corev1.EnvVarArgs{

--- a/global/config.go
+++ b/global/config.go
@@ -19,9 +19,9 @@ type Configuration struct {
 
 		// For lock kind "etcd"
 
-		EtcdEndpoints []string
-		EtcdUsername  string
-		EtcdPassword  string
+		EtcdEndpoint string
+		EtcdUsername string
+		EtcdPassword string
 	}
 
 	OCI struct {

--- a/global/etcd.go
+++ b/global/etcd.go
@@ -15,7 +15,7 @@ var (
 func GetEtcdManager() *etcd.Manager {
 	etcdOnce.Do(func() {
 		etcdInstance = etcd.NewManager(etcd.Config{
-			Endpoint: Conf.Lock.EtcdEndpoints[0], // XXX this support only one endpoint for now
+			Endpoint: Conf.Lock.EtcdEndpoint,
 			Username: Conf.Lock.EtcdUsername,
 			Password: Conf.Lock.EtcdPassword,
 			Logger:   zap.NewNop(), // drop logs

--- a/global/etcd.go
+++ b/global/etcd.go
@@ -1,0 +1,25 @@
+package global
+
+import (
+	"sync"
+
+	"github.com/ctfer-io/chall-manager/pkg/services/etcd"
+)
+
+var (
+	etcdInstance *etcd.Manager
+	etcdOnce     sync.Once
+)
+
+func GetEtcdManager() *etcd.Manager {
+	etcdOnce.Do(func() {
+		etcdInstance = etcd.NewManager(etcd.Config{
+			Endpoint: Conf.Lock.EtcdEndpoints[0], // XXX this support only one endpoint for now
+			Username: Conf.Lock.EtcdUsername,
+			Password: Conf.Lock.EtcdPassword,
+			Logger:   Log().Sub,
+			// TODO add CBOnStateChange
+		})
+	})
+	return etcdInstance
+}

--- a/global/etcd.go
+++ b/global/etcd.go
@@ -19,7 +19,6 @@ func GetEtcdManager() *etcd.Manager {
 			Username: Conf.Lock.EtcdUsername,
 			Password: Conf.Lock.EtcdPassword,
 			Logger:   zap.NewNop(), // drop logs
-			// TODO add CBOnStateChange
 		})
 	})
 	return etcdInstance

--- a/global/etcd.go
+++ b/global/etcd.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"github.com/ctfer-io/chall-manager/pkg/services/etcd"
+	"go.uber.org/zap"
 )
 
 var (
@@ -17,7 +18,7 @@ func GetEtcdManager() *etcd.Manager {
 			Endpoint: Conf.Lock.EtcdEndpoints[0], // XXX this support only one endpoint for now
 			Username: Conf.Lock.EtcdUsername,
 			Password: Conf.Lock.EtcdPassword,
-			Logger:   Log().Sub,
+			Logger:   zap.NewNop(), // drop logs
 			// TODO add CBOnStateChange
 		})
 	})

--- a/go.work.sum
+++ b/go.work.sum
@@ -713,6 +713,7 @@ github.com/containerd/protobuild v0.3.0/go.mod h1:5mNMFKKAwCIAkFBPiOdtRx2KiQlyEJ
 github.com/containerd/ttrpc v1.2.7/go.mod h1:YCXHsb32f+Sq5/72xHubdiJRQY9inL4a4ZQrAbN1q9o=
 github.com/containerd/typeurl v1.0.2 h1:Chlt8zIieDbzQFzXzAeBEF92KhExuE4p9p92/QmY7aY=
 github.com/containerd/typeurl v1.0.2/go.mod h1:9trJWW2sRlGub4wZJRTW83VtbOLS6hwcDZXTn6oPz9s=
+github.com/containerd/typeurl/v2 v2.2.0/go.mod h1:8XOOxnyatxSWuG8OfsZXVnAF4iZfedjS/8UHSPJnX4g=
 github.com/containerd/typeurl/v2 v2.2.3/go.mod h1:95ljDnPfD3bAbDJRugOiShd/DlAAsxGtUBhJxIn7SCk=
 github.com/containerd/zfs v1.1.0/go.mod h1:oZF9wBnrnQjpWLaPKEinrx3TQ9a+W/RJO7Zb41d8YLE=
 github.com/containernetworking/cni v1.1.2/go.mod h1:sDpYKmGVENF3s6uvMvGgldDWeG8dMxakj/u+i9ht9vw=
@@ -1081,6 +1082,7 @@ github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJ
 github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/go-wordwrap v0.0.0-20150314170334-ad45545899c7/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUbP2oI0UX1GXzOo=
 github.com/mmcloughlin/avo v0.5.0/go.mod h1:ChHFdoV7ql95Wi7vuq2YT1bwCJqiWdZrQ1im3VujLYM=
+github.com/moby/locker v1.0.1/go.mod h1:S7SDdo5zpBK84bzzVlKr2V0hz+7x9hWbYC/kq7oQppc=
 github.com/moby/moby v23.0.3+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby v25.0.4+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/moby/moby v26.1.0+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
@@ -1088,6 +1090,9 @@ github.com/moby/moby v26.1.5+incompatible/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHs
 github.com/moby/spdystream v0.2.0/go.mod h1:f7i0iNDQJ059oMTcWxx8MA/zKFIuD/lY+0GqbN2Wy8c=
 github.com/moby/spdystream v0.4.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/spdystream v0.5.0/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
+github.com/moby/sys/mount v0.3.4/go.mod h1:KcQJMbQdJHPlq5lcYT+/CjatWM4PuxKe+XLSVS4J6Os=
+github.com/moby/sys/mountinfo v0.7.2/go.mod h1:1YOa8w8Ih7uW0wALDUgT1dTTSBrZ+HiBLGws92L2RU4=
+github.com/moby/sys/reexec v0.1.0/go.mod h1:EqjBg8F3X7iZe5pU6nRZnYCMUTXoxsjiIfHup5wYIN8=
 github.com/moby/sys/sequential v0.5.0/go.mod h1:tH2cOOs5V9MlPiXcQzRC+eEyab644PWKGRYaaV5ZZlo=
 github.com/moby/sys/signal v0.7.0/go.mod h1:GQ6ObYZfqacOwTtlXvcmh9A26dVRul/hbOZn88Kg8Tg=
 github.com/moby/sys/symlink v0.2.0/go.mod h1:7uZVF2dqJjG/NsClqul95CqKOBRQyYSNnJ6BMgR/gFs=
@@ -1395,6 +1400,7 @@ go.uber.org/automaxprocs v1.5.3/go.mod h1:eRbA25aqJrxAbsLO0xy5jVwPt7FQnRgjW+efnw
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
 go.uber.org/multierr v1.10.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
+go.uber.org/zap/exp v0.3.0/go.mod h1:5I384qq7XGxYyByIhHm6jg5CHkGY0nsTfbDLgDDlgJQ=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190911031432-227b76d455e7/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=

--- a/pkg/lock/concurrency.go
+++ b/pkg/lock/concurrency.go
@@ -24,16 +24,16 @@ type RWLock interface {
 	// RWUnlock is a writer unlock
 	RWUnlock(context.Context) error
 
-	// Close network socket/connections
+	// Close sessions
 	Close() error
 }
 
-func NewRWLock(key string) (RWLock, error) {
+func NewRWLock(ctx context.Context, key string) (RWLock, error) {
 	switch global.Conf.Lock.Kind {
 	case "local":
 		return NewLocalRWLock(key)
 	case "etcd":
-		return NewEtcdRWLock(key)
+		return NewEtcdRWLock(ctx, key)
 	}
 	panic("unhandled lock kind " + global.Conf.Lock.Kind)
 }

--- a/pkg/lock/etcd.go
+++ b/pkg/lock/etcd.go
@@ -5,40 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
-	"sync"
 
 	"github.com/ctfer-io/chall-manager/global"
-	"github.com/sony/gobreaker/v2"
-	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 )
-
-var (
-	etcdCli  *clientv3.Client
-	etcdOnce sync.Once
-)
-
-func getClient() *clientv3.Client {
-	etcdOnce.Do(func() {
-		cli, err := clientv3.New(clientv3.Config{
-			Endpoints: global.Conf.Lock.EtcdEndpoints,
-			Username:  global.Conf.Lock.EtcdUsername,
-			Password:  global.Conf.Lock.EtcdPassword,
-			Logger:    zap.NewNop(), // Disable logger for etcd as it spams logs
-			DialOptions: []grpc.DialOption{
-				grpc.WithStatsHandler(otelgrpc.NewClientHandler()), // propagate OTEL span info
-			},
-		})
-		if err != nil {
-			panic("failed to init etcd client: " + err.Error())
-		}
-		etcdCli = cli
-	})
-	return etcdCli
-}
 
 // The etcd distributed lock enables you to have a powerful mutual exclusion (mutex)
 // system in with an etcd cluster.
@@ -48,16 +19,12 @@ func getClient() *clientv3.Client {
 //
 // This implementation goes further than a simple mutex, as it implements the
 // readers-writer lock for a writer-preference.
-// Moreover, it implements a circuit breaker under the hood to handle network failures
-// smoothly.
 //
 // Based upon 'Concurrent Control with "Readers" and "Writers"' by Courtois et al. (1971)
 // DOI: 10.1145/362759.362813
 type EtcdRWLock struct {
 	key string
 	s   *concurrency.Session
-
-	cb *gobreaker.CircuitBreaker[struct{}]
 
 	// readCounter  -> /chall-manager/<key>/readCounter
 	// writeCounter -> /chall-manager/<key>/writeCounter
@@ -69,22 +36,16 @@ type EtcdRWLock struct {
 	// w  -> /chall-manager/<key>/w
 }
 
-func NewEtcdRWLock(key string) (RWLock, error) {
-	s, err := concurrency.NewSession(getClient())
+func NewEtcdRWLock(ctx context.Context, key string) (RWLock, error) {
+	s, err := global.GetEtcdManager().NewConcurrencySession(ctx)
 	if err != nil {
 		return nil, err
 	}
-
-	// TODO pipe CircuitBreaker status into telemetry data, follow Netflix Hystrix approach ?
-	cb := gobreaker.NewCircuitBreaker[struct{}](gobreaker.Settings{
-		Name: key,
-	})
 
 	pfx := "/chall-manager/" + key + "/"
 	return &EtcdRWLock{
 		key: key,
 		s:   s,
-		cb:  cb,
 		m1:  concurrency.NewMutex(s, pfx+"m1"),
 		m2:  concurrency.NewMutex(s, pfx+"m2"),
 		m3:  concurrency.NewMutex(s, pfx+"m3"),
@@ -98,201 +59,182 @@ func (lock *EtcdRWLock) Key() string {
 }
 
 func (lock *EtcdRWLock) RLock(ctx context.Context) error {
-	_, err := lock.cb.Execute(func() (_ struct{}, err error) {
-		if err = lock.m3.Lock(ctx); err != nil {
-			return
-		}
-		defer unlock(ctx, lock.m3)
+	etcdCli := global.GetEtcdManager()
 
-		if err = lock.r.Lock(ctx); err != nil {
-			return
-		}
-		defer unlock(ctx, lock.r)
+	if err := lock.m3.Lock(ctx); err != nil {
+		return err
+	}
+	defer unlock(ctx, lock.m3)
 
-		if err = lock.m1.Lock(ctx); err != nil {
-			return
-		}
-		defer unlock(ctx, lock.m1)
+	if err := lock.r.Lock(ctx); err != nil {
+		return err
+	}
+	defer unlock(ctx, lock.r)
 
-		k := fmt.Sprintf("/chall-manager/%s/readCounter", lock.key)
-		res, err := etcdCli.Get(ctx, k)
+	if err := lock.m1.Lock(ctx); err != nil {
+		return err
+	}
+	defer unlock(ctx, lock.m1)
+
+	k := fmt.Sprintf("/chall-manager/%s/readCounter", lock.key)
+	res, err := etcdCli.Get(ctx, k)
+	if err != nil {
+		return err
+	}
+	var readCounter int
+	switch len(res.Kvs) {
+	case 0:
+		readCounter = 0
+	case 1:
+		str := string(res.Kvs[0].Value)
+		readCounter, err = strconv.Atoi(str)
 		if err != nil {
-			return
+			return errors.New("invalid format for " + k + ", got " + str)
 		}
-		var readCounter int
-		switch len(res.Kvs) {
-		case 0:
-			readCounter = 0
-		case 1:
-			str := string(res.Kvs[0].Value)
-			readCounter, err = strconv.Atoi(str)
-			if err != nil {
-				err = errors.New("invalid format for " + k + ", got " + str)
-				return
-			}
-		default:
-			err = errors.New("invalid etcd filter for " + k)
-			return
-		}
-		readCounter++
-		_, perr := etcdCli.Put(ctx, k, strconv.Itoa(readCounter))
-		// Don't return perr for now, let's avoid race conditions and starvations
+	default:
+		return errors.New("invalid etcd filter for " + k)
+	}
+	readCounter++
+	_, perr := etcdCli.Put(ctx, k, strconv.Itoa(readCounter))
+	// Don't return perr for now, let's avoid race conditions and starvations
 
-		if readCounter == 1 {
-			if err = lock.w.Lock(ctx); err != nil {
-				return
-			}
+	if readCounter == 1 {
+		if err := lock.w.Lock(ctx); err != nil {
+			return err
 		}
+	}
 
-		err = perr
-		return
-	})
-	return err
+	return perr
 }
 
 func (lock *EtcdRWLock) RUnlock(ctx context.Context) error {
-	_, err := lock.cb.Execute(func() (_ struct{}, err error) {
-		if err = lock.m1.Lock(ctx); err != nil {
-			return
-		}
-		defer unlock(ctx, lock.m1)
+	etcdCli := global.GetEtcdManager()
 
-		k := fmt.Sprintf("/chall-manager/%s/readCounter", lock.key)
-		res, err := etcdCli.Get(ctx, k)
+	if err := lock.m1.Lock(ctx); err != nil {
+		return err
+	}
+	defer unlock(ctx, lock.m1)
+
+	k := fmt.Sprintf("/chall-manager/%s/readCounter", lock.key)
+	res, err := etcdCli.Get(ctx, k)
+	if err != nil {
+		return err
+	}
+	var readCounter int
+	switch len(res.Kvs) {
+	case 1:
+		str := string(res.Kvs[0].Value)
+		readCounter, err = strconv.Atoi(str)
 		if err != nil {
-			return
+			return errors.New("invalid format for " + k + ", got " + str)
 		}
-		var readCounter int
-		switch len(res.Kvs) {
-		case 1:
-			str := string(res.Kvs[0].Value)
-			readCounter, err = strconv.Atoi(str)
-			if err != nil {
-				err = errors.New("invalid format for " + k + ", got " + str)
-				return
-			}
-		default:
-			err = errors.New("invalid etcd filter for " + k)
-			return
-		}
-		readCounter--
-		_, perr := etcdCli.Put(ctx, k, strconv.Itoa(readCounter))
-		// Don't return perr for now, let's avoid race conditions and starvations
+	default:
+		return errors.New("invalid etcd filter for " + k)
+	}
+	readCounter--
+	_, perr := etcdCli.Put(ctx, k, strconv.Itoa(readCounter))
+	// Don't return perr for now, let's avoid race conditions and starvations
 
-		if readCounter == 0 {
-			if err = lock.w.Unlock(ctx); err != nil {
-				return
-			}
+	if readCounter == 0 {
+		if err := lock.w.Unlock(ctx); err != nil {
+			return err
 		}
+	}
 
-		err = perr
-		return
-	})
-	return err
+	return perr
 }
 
 func (lock *EtcdRWLock) RWLock(ctx context.Context) error {
-	_, err := lock.cb.Execute(func() (_ struct{}, err error) {
-		defer func(ctx context.Context, mx *concurrency.Mutex) {
-			if err := mx.Lock(ctx); err != nil {
-				global.Log().Error(ctx, "failed to lock etcd mutex",
-					zap.Error(err),
-					zap.String("key", mx.Key()),
-				)
-			}
-		}(ctx, lock.w)
+	etcdCli := global.GetEtcdManager()
 
-		if err = lock.m2.Lock(ctx); err != nil {
-			return
+	defer func(ctx context.Context, mx *concurrency.Mutex) {
+		if err := mx.Lock(ctx); err != nil {
+			global.Log().Error(ctx, "failed to lock etcd mutex",
+				zap.Error(err),
+				zap.String("key", mx.Key()),
+			)
 		}
-		defer unlock(ctx, lock.m2)
+	}(ctx, lock.w)
 
-		k := fmt.Sprintf("/chall-manager/%s/writeCounter", lock.key)
-		res, err := etcdCli.Get(ctx, k)
+	if err := lock.m2.Lock(ctx); err != nil {
+		return err
+	}
+	defer unlock(ctx, lock.m2)
+
+	k := fmt.Sprintf("/chall-manager/%s/writeCounter", lock.key)
+	res, err := etcdCli.Get(ctx, k)
+	if err != nil {
+		return err
+	}
+	var writeCounter int
+	switch len(res.Kvs) {
+	case 0:
+		writeCounter = 0
+	case 1:
+		str := string(res.Kvs[0].Value)
+		writeCounter, err = strconv.Atoi(str)
 		if err != nil {
-			return
+			return errors.New("invalid format for " + k + ", got " + str)
 		}
-		var writeCounter int
-		switch len(res.Kvs) {
-		case 0:
-			writeCounter = 0
-		case 1:
-			str := string(res.Kvs[0].Value)
-			writeCounter, err = strconv.Atoi(str)
-			if err != nil {
-				err = errors.New("invalid format for " + k + ", got " + str)
-				return
-			}
-		default:
-			err = errors.New("invalid etcd filter for " + k)
-			return
-		}
-		writeCounter++
-		_, perr := etcdCli.Put(ctx, k, strconv.Itoa(writeCounter))
-		// Don't return perr for now, let's avoid race conditions and starvations
+	default:
+		return errors.New("invalid etcd filter for " + k)
+	}
+	writeCounter++
+	_, perr := etcdCli.Put(ctx, k, strconv.Itoa(writeCounter))
+	// Don't return perr for now, let's avoid race conditions and starvations
 
-		if writeCounter == 1 {
-			if err = lock.r.Lock(ctx); err != nil {
-				return
-			}
+	if writeCounter == 1 {
+		if err := lock.r.Lock(ctx); err != nil {
+			return err
 		}
+	}
 
-		err = perr
-		return
-	})
-	return err
+	return perr
 }
 
 func (lock *EtcdRWLock) RWUnlock(ctx context.Context) error {
-	_, err := lock.cb.Execute(func() (_ struct{}, err error) {
-		if err = lock.w.Unlock(ctx); err != nil {
-			return
-		}
+	etcdCli := global.GetEtcdManager()
 
-		if err = lock.m2.Lock(ctx); err != nil {
-			return
-		}
-		defer unlock(ctx, lock.m2)
+	if err := lock.w.Unlock(ctx); err != nil {
+		return err
+	}
 
-		k := fmt.Sprintf("/chall-manager/%s/writeCounter", lock.key)
-		res, err := etcdCli.Get(ctx, k)
+	if err := lock.m2.Lock(ctx); err != nil {
+		return err
+	}
+	defer unlock(ctx, lock.m2)
+
+	k := fmt.Sprintf("/chall-manager/%s/writeCounter", lock.key)
+	res, err := etcdCli.Get(ctx, k)
+	if err != nil {
+		return err
+	}
+	var writeCounter int
+	switch len(res.Kvs) {
+	case 1:
+		str := string(res.Kvs[0].Value)
+		writeCounter, err = strconv.Atoi(str)
 		if err != nil {
-			return
+			return errors.New("invalid format for " + k + ", got " + str)
 		}
-		var writeCounter int
-		switch len(res.Kvs) {
-		case 1:
-			str := string(res.Kvs[0].Value)
-			writeCounter, err = strconv.Atoi(str)
-			if err != nil {
-				err = errors.New("invalid format for " + k + ", got " + str)
-				return
-			}
-		default:
-			err = errors.New("invalid etcd filter for " + k)
-			return
-		}
-		writeCounter--
-		_, perr := etcdCli.Put(ctx, k, strconv.Itoa(writeCounter))
-		// Don't return perr for now, let's avoid race conditions and starvations
+	default:
+		return errors.New("invalid etcd filter for " + k)
+	}
+	writeCounter--
+	_, perr := etcdCli.Put(ctx, k, strconv.Itoa(writeCounter))
+	// Don't return perr for now, let's avoid race conditions and starvations
 
-		if writeCounter == 0 {
-			if err = lock.r.Unlock(ctx); err != nil {
-				return
-			}
+	if writeCounter == 0 {
+		if err := lock.r.Unlock(ctx); err != nil {
+			return err
 		}
+	}
 
-		err = perr
-		return
-	})
-	return err
+	return perr
 }
 
 func (lock *EtcdRWLock) Close() error {
-	_, err := lock.cb.Execute(func() (struct{}, error) {
-		return struct{}{}, lock.s.Close()
-	})
-	return err
+	return lock.s.Close()
 }
 
 func unlock(ctx context.Context, mx *concurrency.Mutex) {

--- a/pkg/services/etcd/manager.go
+++ b/pkg/services/etcd/manager.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/sony/gobreaker/v2"
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/client/v3/concurrency"
 	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
@@ -16,8 +15,6 @@ type Manager struct {
 	mu     sync.RWMutex
 	client *clientv3.Client
 	config Config
-
-	breaker *gobreaker.CircuitBreaker[any]
 }
 
 type Config struct {
@@ -25,17 +22,11 @@ type Config struct {
 	Username string
 	Password string
 	Logger   *zap.Logger
-
-	CBOnStateChange func(name string, from, to gobreaker.State)
 }
 
 func NewManager(config Config) *Manager {
 	return &Manager{
 		config: config,
-		breaker: gobreaker.NewCircuitBreaker[any](gobreaker.Settings{
-			Name:          "etcd circuit breaker",
-			OnStateChange: config.CBOnStateChange,
-		}),
 	}
 }
 

--- a/pkg/services/etcd/manager.go
+++ b/pkg/services/etcd/manager.go
@@ -1,0 +1,131 @@
+package etcd
+
+import (
+	"context"
+	"sync"
+
+	"github.com/sony/gobreaker/v2"
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.etcd.io/etcd/client/v3/concurrency"
+	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+)
+
+type Manager struct {
+	mu     sync.RWMutex
+	client *clientv3.Client
+	config Config
+
+	breaker *gobreaker.CircuitBreaker[any]
+}
+
+type Config struct {
+	Endpoint string
+	Username string
+	Password string
+	Logger   *zap.Logger
+
+	CBOnStateChange func(name string, from, to gobreaker.State)
+}
+
+func NewManager(config Config) *Manager {
+	return &Manager{
+		config: config,
+		breaker: gobreaker.NewCircuitBreaker[any](gobreaker.Settings{
+			Name:          "etcd circuit breaker",
+			OnStateChange: config.CBOnStateChange,
+		}),
+	}
+}
+
+func (m *Manager) getClient(ctx context.Context) (*clientv3.Client, error) {
+	m.mu.RLock()
+	client := m.client
+	m.mu.RUnlock()
+
+	if client != nil {
+		if _, err := client.Status(ctx, m.config.Endpoint); err == nil {
+			return client, nil
+		}
+	}
+
+	return m.recreateClient(ctx)
+}
+
+func (m *Manager) recreateClient(ctx context.Context) (*clientv3.Client, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.client != nil {
+		if _, err := m.client.Status(ctx, m.config.Endpoint); err == nil {
+			return m.client, nil
+		}
+		_ = m.client.Close()
+		m.client = nil
+	}
+
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints: []string{m.config.Endpoint},
+		Username:  m.config.Username,
+		Password:  m.config.Password,
+		Logger:    m.config.Logger,
+		DialOptions: []grpc.DialOption{
+			grpc.WithStatsHandler(otelgrpc.NewClientHandler()),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if _, err := cli.Status(ctx, m.config.Endpoint); err != nil {
+		_ = cli.Close()
+		return nil, err
+	}
+
+	m.client = cli
+	return cli, nil
+}
+
+func (m *Manager) NewConcurrencySession(ctx context.Context) (*concurrency.Session, error) {
+	cli, err := m.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return concurrency.NewSession(cli)
+}
+
+func (m *Manager) Get(ctx context.Context, k string) (*clientv3.GetResponse, error) {
+	cli, err := m.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cli.Get(ctx, k)
+}
+
+func (m *Manager) Put(ctx context.Context, k, v string) (*clientv3.PutResponse, error) {
+	cli, err := m.getClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return cli.Put(ctx, k, v)
+}
+
+func (m *Manager) Healthcheck(ctx context.Context) error {
+	cli, err := m.getClient(ctx)
+	if err != nil {
+		return err
+	}
+	if _, err = cli.Status(ctx, m.config.Endpoint); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) Close(ctx context.Context) error {
+	cli, err := m.getClient(ctx)
+	if err != nil {
+		return err
+	}
+	return cli.Close()
+}

--- a/server/healthcheck.go
+++ b/server/healthcheck.go
@@ -23,7 +23,7 @@ func healthcheck(ctx context.Context) http.Handler {
 		panic(err)
 	}
 
-	if len(global.Conf.Lock.EtcdEndpoints) != 0 {
+	if global.Conf.Lock.EtcdEndpoint != "" {
 		global.Log().Info(ctx, "registering healthcheck config",
 			zap.String("service", "etcd"),
 		)

--- a/server/healthcheck.go
+++ b/server/healthcheck.go
@@ -7,10 +7,7 @@ import (
 
 	"github.com/ctfer-io/chall-manager/global"
 	"github.com/hellofresh/health-go/v5"
-	clientv3 "go.etcd.io/etcd/client/v3"
-	"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"
 	"go.uber.org/zap"
-	"google.golang.org/grpc"
 )
 
 func healthcheck(ctx context.Context) http.Handler {
@@ -31,24 +28,13 @@ func healthcheck(ctx context.Context) http.Handler {
 			zap.String("service", "etcd"),
 		)
 
-		// TODO connect this to the CircuitBreaker, and shares a global structure around this
 		_ = h.Register(health.Config{
 			Name:    "etcd",
 			Timeout: time.Second,
 			Check: func(ctx context.Context) error {
-				_, err := clientv3.New(clientv3.Config{
-					Context:   ctx,
-					Endpoints: global.Conf.Lock.EtcdEndpoints,
-					Username:  global.Conf.Lock.EtcdUsername,
-					Password:  global.Conf.Lock.EtcdPassword,
-					Logger:    global.Log().Sub,
-					DialOptions: []grpc.DialOption{
-						grpc.WithStatsHandler(otelgrpc.NewClientHandler()), // propagate OTEL span info
-					},
-				})
-				return err
+				man := global.GetEtcdManager()
+				return man.Healthcheck(ctx)
 			},
-			SkipOnErr: true,
 		})
 	}
 


### PR DESCRIPTION
This PR improves the management of external services. The new pattern is applied on `etcd`. It transitively seems like to fix the problem of log on the `retry_interceptor.go` file from `etcdv3/client` :tada:.
A lot of files are modified simply to pass the `context.Context`.

The pattern is simple :
- a `Manager` centralizes access to the service, mapping necessary methods ;
- the `global` package has a singleton to this service, used whenever required ;
- on networking issues, the `Manager` handles resiliency (for now nothing special is implemented, will be a focus when starting chaos engineering work) ;
- the _healthcheck_ is plugged into this `Manager` such that we do not duplicate connections and their management.

Future needs could do similarly to connect to other services whenever required.

To test proper work with an etcd cluster, I add a smoke test.

To simplify access to the etcd service, I introduce a :rotating_light: **breaking change** :rotating_light: in the CLI: it only support one etcd endpoint. The change has been reflected to the Pulumi program, but has no impact over the API as we never used multiple etcd endpoints.