### PR TITLE
impr(otel): component version and caller function name in traces

### DIFF
--- a/global/etcd.go
+++ b/global/etcd.go
@@ -19,6 +19,7 @@ func GetEtcdManager() *etcd.Manager {
 			Username: Conf.Lock.EtcdUsername,
 			Password: Conf.Lock.EtcdPassword,
 			Logger:   zap.NewNop(), // drop logs
+			Tracer:   Tracer,       // inject the global OTel tracer
 		})
 	})
 	return etcdInstance

--- a/global/otel.go
+++ b/global/otel.go
@@ -110,6 +110,7 @@ func SetupOtelSDK(ctx context.Context) (shutdown func(context.Context) error, er
 		resource.NewWithAttributes(
 			semconv.SchemaURL,
 			semconv.ServiceName(Conf.Otel.ServiceName),
+			semconv.ServiceVersion(Version),
 		),
 	)
 	if err != nil {

--- a/pkg/otel/caller.go
+++ b/pkg/otel/caller.go
@@ -1,0 +1,83 @@
+package otel
+
+import (
+	"context"
+	"runtime"
+
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
+)
+
+func UnaryClientInterceptorWithCaller(tracer trace.Tracer) grpc.UnaryClientInterceptor {
+	return func(
+		ctx context.Context,
+		method string,
+		req, reply any,
+		cc *grpc.ClientConn,
+		invoker grpc.UnaryInvoker,
+		opts ...grpc.CallOption,
+	) error {
+		// Determine caller name
+		pc, _, _, ok := runtime.Caller(2)
+		caller := "unknown"
+		if ok {
+			if fn := runtime.FuncForPC(pc); fn != nil {
+				caller = fn.Name()
+			}
+		}
+
+		// Start span for the unary
+		ctx, span := tracer.Start(ctx, method)
+		defer span.End()
+		span.SetAttributes(attribute.String("caller.function", caller))
+
+		return invoker(ctx, method, req, reply, cc, opts...)
+	}
+}
+
+func StreamClientInterceptorWithCaller(tracer trace.Tracer) grpc.StreamClientInterceptor {
+	return func(
+		ctx context.Context,
+		desc *grpc.StreamDesc,
+		cc *grpc.ClientConn,
+		method string,
+		streamer grpc.Streamer,
+		opts ...grpc.CallOption,
+	) (grpc.ClientStream, error) {
+		// Determine caller name
+		pc, _, _, ok := runtime.Caller(2)
+		caller := "unknown"
+		if ok {
+			if fn := runtime.FuncForPC(pc); fn != nil {
+				caller = fn.Name()
+			}
+		}
+
+		// Start span for the stream
+		ctx, span := tracer.Start(ctx, method)
+		span.SetAttributes(attribute.String("caller.function", caller))
+
+		// Call the actual streamer to get the client stream
+		clientStream, err := streamer(ctx, desc, cc, method, opts...)
+		if err != nil {
+			span.RecordError(err)
+			span.End()
+			return nil, err
+		}
+
+		// Wrap the client stream to end the span when the stream is closed
+		return &wrappedClientStream{ClientStream: clientStream, span: span}, nil
+	}
+}
+
+type wrappedClientStream struct {
+	grpc.ClientStream
+	span trace.Span
+}
+
+func (w *wrappedClientStream) CloseSend() error {
+	err := w.ClientStream.CloseSend()
+	w.span.End()
+	return err
+}


### PR DESCRIPTION
In this PR I propose to improve the OTel support by adding the `service.version` conventional attribute to the tracer.

I also would like to introduce the `caller.function` such that, in traces, we are aware of which function emitted the call.
This finds value when trying to understand from where a call has been issued from one microservice to an other.
I wrap both unaries and streams, and make them available for others who would like to rely on it too using `github.com/ctfer-io/chall-manager/pkg/otel` package.

It changes no behavior and has impact only when `tracing` is on.