### PR TITLE
fix(lint): disable revive's var-naming on package names

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,6 +18,13 @@ linters:
       excludes:
         - G401
         - G501
+    revive:
+      rules:
+        - name: var-naming
+          arguments:
+            - []
+            - []
+            - - skipPackageNameChecks: true
   exclusions:
     generated: lax
     presets:


### PR DESCRIPTION
This PR disables revive's `var-naming` rule for package names.
It has been recently introduced, but we do not want such check as we are using shared functionalities between API's gRPC services (e.g. locks).

For 2 weeks it has flagged all MCO _PRs_ invalid, and will keep going if we don't fix it...