### PR TITLE
Run CI when required

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,16 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    paths:
+      - '.github/workflows/*.yaml'
+      - '**.go'
+      - '**.proto'
+  pull_request:
+    paths:
+      - '.github/workflows/*.yaml'
+      - '**.go'
+      - '**.proto'
 
 permissions:
   contents: read

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -51,7 +51,6 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION_LDFLAGS: ${{ steps.ldflags.outputs.version }}
 
       - name: Generate subject
         id: hash
@@ -90,16 +89,11 @@ jobs:
           git config --local user.email "ctfer-io@protonmail.com"
           git config --local user.name "ctfer-io[bot]"
 
-      - name: Get Tag Name
-        run: |
-          REF_NAME=$(git describe --abbrev=0 --tags)
-          echo "REF_NAME=${REF_NAME}" >> $GITHUB_ENV
-
       - name: Tag alternatives
         run: |
-          git tag -a sdk/${{ env.REF_NAME }} -m sdk/${{ env.REF_NAME }}
-          git tag -a deploy/${{ env.REF_NAME }} -m deploy/${{ env.REF_NAME }}
+          git tag -a sdk/${{ github.ref_name }} -m sdk/${{ github.ref_name }}
+          git tag -a deploy/${{ github.ref_name }} -m deploy/${{ github.ref_name }}
       - name: Push to Repository
         run: |
-          git push origin sdk/${{ env.REF_NAME }}
-          git push origin deploy/${{ env.REF_NAME }}
+          git push origin sdk/${{ github.ref_name }}
+          git push origin deploy/${{ github.ref_name }}


### PR DESCRIPTION
This PR proposes to only run the CI (unit/e2e tests + lint) only when Go or proto files are modified. It also runs on workflow update (e.g. dependabot PRs) to ensure there are no sudden breaking changes (e.g. golangci-lint recently added a package name lint rule which suddenly broke CI).

It should boost up the PR review time, especially for documentation.

Finally I fix the version settings by removing the ldflags (relica) and directly use github context environments.