### PR TITLE
impr(deploy): add k=v env map

### DIFF
--- a/deploy/main.go
+++ b/deploy/main.go
@@ -29,6 +29,7 @@ func main() {
 			Kubeconfig:     cfg.Kubeconfig,
 			Requests:       pulumi.ToStringMap(cfg.Requests),
 			Limits:         pulumi.ToStringMap(cfg.Limits),
+			Envs:           pulumi.ToStringMap(cfg.Envs),
 		}
 		if cfg.Etcd != nil {
 			args.EtcdReplicas = pulumi.IntPtr(cfg.Etcd.Replicas)
@@ -86,6 +87,7 @@ type (
 		CmToApiServerTemplate string
 		Otel                  *OtelConfig
 		OCI                   *OCIConfig
+		Envs                  map[string]string
 
 		// Secrets
 
@@ -137,6 +139,10 @@ func loadConfig(ctx *pulumi.Context) *Config {
 
 	if err := cfg.TryObject("limits", &c.Limits); err != nil {
 		panic(err)
+	}
+
+	if err := cfg.TryObject("envs", &c.Envs); err != nil {
+		c.Envs = map[string]string{}
 	}
 
 	var etcdC EtcdConfig

--- a/deploy/services/chall-manager.go
+++ b/deploy/services/chall-manager.go
@@ -102,6 +102,9 @@ type (
 		// https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
 		Limits pulumi.StringMapInput
 
+		// A key=value map of additional environment variables to mount in Chall-Manager.
+		Envs pulumi.StringMapInput
+
 		// CmToApiServerTemplate is a Go text/template that defines the NetworkPolicy
 		// YAML schema to use.
 		// If none set, it is defaulted to a cilium.io/v2 CiliumNetworkPolicy.
@@ -359,6 +362,7 @@ func (cm *ChallManager) provision(ctx *pulumi.Context, args *ChallManagerArgs, o
 		Kubeconfig:     args.Kubeconfig,
 		Requests:       args.Requests,
 		Limits:         args.Limits,
+		Envs:           args.Envs,
 		OCIInsecure:    args.OCIInsecure,
 		OCIUsername:    args.OCIUsername,
 		OCIPassword:    args.OCIPassword,


### PR DESCRIPTION
Re-add the capability to set environment variables (venv) for `chall-manager`.
In case of overlap, the provided venvs override existing ones.

This might be very helpful for #779 as we would be able to define things like `GOPROXY` for Go, or `PULUMI_PLUGIN_DOWNLOAD_URL_OVERRIDES` for Pulumi.
For now -at least- I don't explicitly specify them in the the stack configuration, and is kind of a shadow stack configuration attribute (+ it must be set per `--path` not per `--plaintext` so is not usable within the integration tests).

It could also be useful when deploying with sensitive systems credentials (e.g. a Proxmox API token), such that you avoid hardcoding them within _scenarios_.