### PR TITLE
docs: add pwnlentoni/prism-ctf as an alternative

### DIFF
--- a/webdocs/design/the-need/index.md
+++ b/webdocs/design/the-need/index.md
@@ -131,6 +131,17 @@ To enhance it please open an issue or a pull request, we would be glad to improv
         <td>Create AWS ECS tasks to host Docker containers</td>
         <!--Scalable-->
         <td align="center">✅</td>
+    </tr><tr>
+        <!--Service-->
+        <td><a href="https://github.com/pwnlentoni/prism-ctf">pwnlentoni's prism-ctf</a></td>
+        <!--CTF platform-->
+        <td>Agnostic, <a href="https://github.com/pwnlentoni/prism-ctf-ctfd">CTFd plugin</a></td>
+        <!--Genericity-->
+        <td align="center">❌</td>
+        <!--Technical approach-->
+        <td>Use Kubernetes CRDs and a microservice</td>
+        <!--Scalable-->
+        <td align="center">✅</td>
     </tr>
 </table>
 


### PR DESCRIPTION
This PR adds [pwnlentoni/prism-ctf](https://github.com/pwnlentoni/prism-ctf) in the list of alternatives. It has been showcased during [CCIT 2025](https://ccitt2025.org/).

I discovered them while searching the internet for Chall-Manager references :eyes:

---

Regarding the criticism over the complexity of Chall-Manager, we are well aware of this problem: we can't have such abstraction over scenarios without drawbacks in their complexity. This is the reason we are designing a [SDK](https://github.com/ctfer-io/chall-manager/tree/main/sdk), later transformed in [recipes](https://github.com/ctfer-io/recipes). Even if not public yet, these are included in [CTFOps](https://github.com/ctfer-io/ctfops) for YAML descriptions, with auto-completion, default values and inferred values (as much as possible).

In the end, it is cool to see alternatives being developed: there is room for CM and the tooling to improve further, even on Kubernetes resources we have been supporting from the early days ! :rocket: 