### PR TITLE
fix(#886): add annotations support per port exposed of each container

### DIFF
--- a/sdk/kubernetes/exposed-multipod.go
+++ b/sdk/kubernetes/exposed-multipod.go
@@ -559,7 +559,8 @@ func (emp *exposedMultipod) provision(ctx *pulumi.Context, args ExposedMultipodA
 
 			svc, err := corev1.NewService(ctx, fmt.Sprintf("emp-svc-%s-%d", rawName, i), &corev1.ServiceArgs{
 				Metadata: metav1.ObjectMetaArgs{
-					Labels: labels,
+					Annotations: p.ServiceAnnotations(),
+					Labels:      labels,
 					Name: pulumi.All(args.Identity(), args.Label(), name, p.Port(), p.Protocol()).ApplyT(func(all []any) string {
 						id := all[0].(string)
 						name := all[2].(string)

--- a/sdk/kubernetes/port.go
+++ b/sdk/kubernetes/port.go
@@ -22,6 +22,10 @@ type PortBinding struct {
 
 	// ExposeType is the [ExposeType] strategy to expose the port.
 	ExposeType ExposeType `pulumi:"exposeType"`
+
+	// ServiceAnnotations is an optional k=v map of annotations to set on
+	// the service that exposes the container on this port.
+	ServiceAnnotations map[string]string `pulumi:"serviceAnnotations"`
 }
 
 type PortBindingInput interface {
@@ -43,6 +47,10 @@ type PortBindingArgs struct {
 
 	// ExposeType is the [ExposeType] strategy to expose the port.
 	ExposeType ExposeTypeInput `pulumi:"exposeType"`
+
+	// ServiceAnnotations is an optional k=v map of annotations to set on
+	// the service that exposes the container on this port.
+	ServiceAnnotations pulumi.StringMapInput `pulumi:"serviceAnnotations"`
 }
 
 func (PortBindingArgs) ElementType() reflect.Type {
@@ -99,6 +107,12 @@ func (o PortBindingOutput) ExposeType() ExposeTypeOutput {
 		}
 		return v.ExposeType
 	}).(ExposeTypeOutput)
+}
+
+func (o PortBindingOutput) ServiceAnnotations() pulumi.StringMapOutput {
+	return o.ApplyT(func(v PortBinding) map[string]string {
+		return v.ServiceAnnotations
+	}).(pulumi.StringMapOutput)
 }
 
 type PortBindingArrayInput interface {


### PR DESCRIPTION
Resolves #886

The core idea is that a container can expose multiple ports, each can be individually controlled depending on your needs. As such, you can now also control the annotations of these services individually :rocket: 