### PR TITLE
[SDK] Improve Kubernetes exposures and annotations

### DIFF
--- a/sdk/kubernetes/exposeType.go
+++ b/sdk/kubernetes/exposeType.go
@@ -22,6 +22,10 @@ const (
 	// ExposeIngress defines a [PortBinding] that is exposed through
 	// a Kubernetes Ingress.
 	ExposeIngress ExposeType = "Ingress"
+
+	// ExposeLoadBalancer defines a [PortBinding] that is exposed through
+	// a Kubernetes Service typed "LoadBalancer".
+	ExposeLoadBalancer ExposeType = "LoadBalancer"
 )
 
 type ExposeTypeInput interface {

--- a/sdk/kubernetes/exposed-monopod.go
+++ b/sdk/kubernetes/exposed-monopod.go
@@ -45,11 +45,10 @@ func NewExposedMonopod(ctx *pulumi.Context, name string, args *ExposedMonopodArg
 		Containers: ContainerMap{
 			"one": argsOut.Container(),
 		},
-		Rules:              RuleArray{},
-		FromCIDR:           argsOut.FromCIDR(),
-		IngressAnnotations: argsOut.IngressAnnotations(),
-		IngressNamespace:   argsOut.IngressNamespace(),
-		IngressLabels:      argsOut.IngressLabels(),
+		Rules:            RuleArray{},
+		FromCIDR:         argsOut.FromCIDR(),
+		IngressNamespace: argsOut.IngressNamespace(),
+		IngressLabels:    argsOut.IngressLabels(),
 	}, opts...)
 	if err != nil {
 		return nil, err
@@ -111,14 +110,13 @@ func (emp *ExposedMonopod) check(args ExposedMonopodArgsOutput) error {
 }
 
 type ExposedMonopodArgsRaw struct {
-	Identity           string            `pulumi:"identity"`
-	Label              *string           `pulumi:"label"`
-	Hostname           string            `pulumi:"hostname"`
-	Container          Container         `pulumi:"container"`
-	FromCIDR           string            `pulumi:"fromCIDR"`
-	IngressAnnotations map[string]string `pulumi:"ingressAnnotations"`
-	IngressNamespace   string            `pulumi:"ingressNamespace"`
-	IngressLabels      map[string]string `pulumi:"ingressLabels"`
+	Identity         string            `pulumi:"identity"`
+	Label            *string           `pulumi:"label"`
+	Hostname         string            `pulumi:"hostname"`
+	Container        Container         `pulumi:"container"`
+	FromCIDR         string            `pulumi:"fromCIDR"`
+	IngressNamespace string            `pulumi:"ingressNamespace"`
+	IngressLabels    map[string]string `pulumi:"ingressLabels"`
 }
 
 type ExposedMonopodArgsInput interface {
@@ -129,14 +127,13 @@ type ExposedMonopodArgsInput interface {
 }
 
 type ExposedMonopodArgs struct {
-	Identity           pulumi.StringInput    `pulumi:"identity"`
-	Label              pulumi.StringPtrInput `pulumi:"label"`
-	Hostname           pulumi.StringInput    `pulumi:"hostname"`
-	Container          ContainerInput        `pulumi:"container"`
-	FromCIDR           pulumi.StringInput    `pulumi:"fromCIDR"`
-	IngressAnnotations pulumi.StringMapInput `pulumi:"ingressAnnotations"`
-	IngressNamespace   pulumi.StringInput    `pulumi:"ingressNamespace"`
-	IngressLabels      pulumi.StringMapInput `pulumi:"ingressLabels"`
+	Identity         pulumi.StringInput    `pulumi:"identity"`
+	Label            pulumi.StringPtrInput `pulumi:"label"`
+	Hostname         pulumi.StringInput    `pulumi:"hostname"`
+	Container        ContainerInput        `pulumi:"container"`
+	FromCIDR         pulumi.StringInput    `pulumi:"fromCIDR"`
+	IngressNamespace pulumi.StringInput    `pulumi:"ingressNamespace"`
+	IngressLabels    pulumi.StringMapInput `pulumi:"ingressLabels"`
 }
 
 func (ExposedMonopodArgs) ElementType() reflect.Type {
@@ -193,12 +190,6 @@ func (o ExposedMonopodArgsOutput) FromCIDR() pulumi.StringOutput {
 	return o.ApplyT(func(args ExposedMonopodArgsRaw) string {
 		return args.FromCIDR
 	}).(pulumi.StringOutput)
-}
-
-func (o ExposedMonopodArgsOutput) IngressAnnotations() pulumi.StringMapOutput {
-	return o.ApplyT(func(args ExposedMonopodArgsRaw) map[string]string {
-		return args.IngressAnnotations
-	}).(pulumi.StringMapOutput)
 }
 
 func (o ExposedMonopodArgsOutput) IngressNamespace() pulumi.StringOutput {

--- a/sdk/kubernetes/exposed-monopod_test.go
+++ b/sdk/kubernetes/exposed-monopod_test.go
@@ -68,16 +68,17 @@ func Test_U_ExposedMonopod(t *testing.T) {
 						k8s.PortBindingArgs{
 							Port:       pulumi.Int(8080),
 							ExposeType: k8s.ExposeIngress,
+							// Based upon default Nginx IngressController settings
+							Annotations: pulumi.StringMap{
+								"kubernetes.io/ingress.class":                  pulumi.String("nginx"),
+								"nginx.ingress.kubernetes.io/backend-protocol": pulumi.String("HTTP"),
+								"nginx.ingress.kubernetes.io/ssl-redirect":     pulumi.String("true"),
+								"nginx.ingress.kubernetes.io/proxy-body-size":  pulumi.String("50m"),
+							},
 						},
 					},
 				},
-				// Following are examples based on Nginx IngressController
-				IngressAnnotations: pulumi.StringMap{
-					"kubernetes.io/ingress.class":                  pulumi.String("nginx"),
-					"nginx.ingress.kubernetes.io/backend-protocol": pulumi.String("HTTP"),
-					"nginx.ingress.kubernetes.io/ssl-redirect":     pulumi.String("true"),
-					"nginx.ingress.kubernetes.io/proxy-body-size":  pulumi.String("50m"),
-				},
+				// Based upon default Nginx IngressController settings
 				IngressNamespace: pulumi.String("ingress-nginx"),
 				IngressLabels: pulumi.ToStringMap(map[string]string{
 					"app.kubernetes.io/component": "controller",

--- a/sdk/kubernetes/exposed-multipod.go
+++ b/sdk/kubernetes/exposed-multipod.go
@@ -948,9 +948,27 @@ func (emp *exposedMultipod) outputs(ctx *pulumi.Context, args ExposedMultipodArg
 
 			urls := map[string]string{}
 			for k, spec := range specs {
-				np := spec.Ports[0].NodePort
-				if np != nil {
-					urls[k] = fmt.Sprintf("%s:%d", hostname, *np)
+				if spec.Type == nil {
+					continue
+				}
+				switch *spec.Type {
+				case "NodePort":
+					np := spec.Ports[0].NodePort
+					if np != nil {
+						urls[k] = fmt.Sprintf("%s:%d", hostname, *np)
+					}
+
+				case "LoadBalancer":
+					// Get both external ip and port.
+					// If in a setup you don't need the port, just cut it out :)
+
+					np := spec.Ports[0].NodePort
+					if np == nil {
+						// If the NodePort has not been assigned yet, we are in a preview
+						// (or all ports in the range are exhausted), so we can skip waiting.
+						continue
+					}
+					urls[k] = fmt.Sprintf("%s:%d", spec.ExternalIPs[0], *np)
 				}
 			}
 			return urls

--- a/sdk/kubernetes/exposed-multipod_test.go
+++ b/sdk/kubernetes/exposed-multipod_test.go
@@ -371,6 +371,47 @@ func Test_U_ExposedMultipod(t *testing.T) {
 			},
 			ExpectErr: true,
 		},
+		"loadbalancer": {
+			Args: &k8s.ExposedMultipodArgs{
+				Identity: pulumi.String("a0b1c2d3"),
+				Hostname: pulumi.String("ctfer.io"),
+				Containers: k8s.ContainerMap{
+					"mongo": k8s.ContainerArgs{
+						Image: pulumi.String("web/vip-only-mongo:v0.1.0"),
+						Ports: k8s.PortBindingArray{
+							k8s.PortBindingArgs{
+								Port: pulumi.Int(27017),
+							},
+						},
+					},
+					"node": k8s.ContainerArgs{
+						Image: pulumi.String("web/vip-only-node:v0.1.0"),
+						Ports: k8s.PortBindingArray{
+							k8s.PortBindingArgs{
+								Port:       pulumi.Int(3000),
+								ExposeType: k8s.ExposeLoadBalancer,
+							},
+						},
+						Files: pulumi.StringMap{
+							"/app/flag.txt": pulumi.String("24HIUT{To0_W3ak_c#yp7o}"),
+						},
+						Envs: k8s.PrinterMap{
+							"MONGODB_URI": k8s.NewPrinter(
+								"mongodb://root:qlaod3a5sdha6s8d6@%s:27017/vipOnlyApp?authSource=admin",
+								"mongo",
+							),
+						},
+					},
+				},
+				Rules: k8s.RuleArray{
+					k8s.RuleArgs{
+						From: pulumi.String("node"),
+						To:   pulumi.String("mongo"),
+						On:   pulumi.Int(27017),
+					},
+				},
+			},
+		},
 	}
 
 	for testname, tt := range tests {

--- a/sdk/kubernetes/kompose_test.go
+++ b/sdk/kubernetes/kompose_test.go
@@ -89,6 +89,22 @@ func Test_U_Kompose(t *testing.T) {
 			},
 			ExpectErr: false,
 		},
+		"loadbalancer": {
+			Args: &k8s.KomposeArgs{
+				Identity: pulumi.String("a0b1c2d3"),
+				Hostname: pulumi.String("24hiut25.ctfer.io"),
+				YAML:     pulumi.String(dcVipOnly),
+				Ports: k8s.PortBindingMapArray{
+					"node": {
+						k8s.PortBindingArgs{
+							Port:       pulumi.Int(3000),
+							ExposeType: k8s.ExposeLoadBalancer,
+						},
+					},
+				},
+			},
+			ExpectErr: false,
+		},
 	}
 
 	for testname, tt := range tests {
@@ -101,7 +117,14 @@ func Test_U_Kompose(t *testing.T) {
 					require.NoError(t, err)
 
 					// We cannot run unit tests on URLs (output)
-					// mocks{} -> no *corev1.Service -> no NodePort nor Ingress -> no URL
+					//
+					// This SDK uses a yaml/v2:ConfigGroup to deploy everything from
+					// the output of a Kompose call. It does not directly create the
+					// objects, especially the core/v1:Service and such even with the
+					// mocks{} implementation.
+					//
+					// We are thus not able to define nodeports, loadbalancer
+					// external IP, nor Ingresses... So cannot tests for URLs validity.
 				}
 
 				return nil

--- a/sdk/kubernetes/port.go
+++ b/sdk/kubernetes/port.go
@@ -23,9 +23,17 @@ type PortBinding struct {
 	// ExposeType is the [ExposeType] strategy to expose the port.
 	ExposeType ExposeType `pulumi:"exposeType"`
 
-	// ServiceAnnotations is an optional k=v map of annotations to set on
-	// the service that exposes the container on this port.
-	ServiceAnnotations map[string]string `pulumi:"serviceAnnotations"`
+	// Annotations is an optional k=v map of annotations to set on
+	// the exposing resource (i.e. service or ingress) that exposes the container
+	// on this port.
+	//
+	// For instance, if the ExposeType=ExposeIngress, then the Annotations are
+	// passed to the Ingress resource.
+	// That could be a place to define pulumi.com/skipAwait=true if needed
+	// References:
+	// - https://www.pulumi.com/blog/improving-kubernetes-management-with-pulumis-await-logic/
+	// - https://github.com/pulumi/pulumi-kubernetes/issues/1812
+	Annotations map[string]string `pulumi:"annotations"`
 }
 
 type PortBindingInput interface {
@@ -48,9 +56,17 @@ type PortBindingArgs struct {
 	// ExposeType is the [ExposeType] strategy to expose the port.
 	ExposeType ExposeTypeInput `pulumi:"exposeType"`
 
-	// ServiceAnnotations is an optional k=v map of annotations to set on
-	// the service that exposes the container on this port.
-	ServiceAnnotations pulumi.StringMapInput `pulumi:"serviceAnnotations"`
+	// Annotations is an optional k=v map of annotations to set on
+	// the exposing resource (i.e. service or ingress) that exposes the container
+	// on this port.
+	//
+	// For instance, if the ExposeType=ExposeIngress, then the Annotations are
+	// passed to the Ingress resource.
+	// That could be a place to define pulumi.com/skipAwait=true if needed
+	// References:
+	// - https://www.pulumi.com/blog/improving-kubernetes-management-with-pulumis-await-logic/
+	// - https://github.com/pulumi/pulumi-kubernetes/issues/1812
+	Annotations pulumi.StringMapInput `pulumi:"annotations"`
 }
 
 func (PortBindingArgs) ElementType() reflect.Type {
@@ -109,9 +125,9 @@ func (o PortBindingOutput) ExposeType() ExposeTypeOutput {
 	}).(ExposeTypeOutput)
 }
 
-func (o PortBindingOutput) ServiceAnnotations() pulumi.StringMapOutput {
+func (o PortBindingOutput) Annotations() pulumi.StringMapOutput {
 	return o.ApplyT(func(v PortBinding) map[string]string {
-		return v.ServiceAnnotations
+		return v.Annotations
 	}).(pulumi.StringMapOutput)
 }
 

--- a/webdocs/tutorials/a-complete-example/index.md
+++ b/webdocs/tutorials/a-complete-example/index.md
@@ -98,14 +98,14 @@ func main() {
 				Image: pulumi.String("account/challenge:latest"), // challenge Docker image
 				Ports: kubernetes.PortBindingArray{
 					kubernetes.PortBindingArgs{
-						Port:       pulumi.Int(8080),
-						ExposeType: kubernetes.ExposeIngress,
+						Port:        pulumi.Int(8080),
+						ExposeType:  kubernetes.ExposeIngress,
+						Annotations: pulumi.ToStringMap(map[string]string{ // annotations for the ingress to target the service
+							"traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
+						}),
 					},
 				},
 			},
-			IngressAnnotations: pulumi.ToStringMap(map[string]string{ // annotations for the ingress to target the service
-				"traefik.ingress.kubernetes.io/router.entrypoints": "web, websecure",
-			}),
 			IngressNamespace: pulumi.String("networking"), // the namespace in which the ingress is deployed
 			IngressLabels: pulumi.ToStringMap(map[string]string{ // the labels of the ingress pods
 				"app": "traefik",


### PR DESCRIPTION
This PR focuses on the `kubernetes` submodule of the SDK, and improves:
1. how are exposed the containers as per `Kompose`, `ExposedMonopod` and `ExposedMultipod`, with a new exposure possibility being `LoadBalancer`;
2. how the annotations are passed to the exposing resources.

## :book: Context

To date, CTFer.io deployments focuses on on-premise infrastructure. With our current stack (MetalLB, Traefik and DNSMasq) we where able to handle all NodePorts/Ingresses and distribute it efficiently to players. It worked fine for up to 200 players in production (at least we didn't have the opportunity to test with more, and I don't see why it would not work -- except a possible nodeport exhaustion).

Now, with way larger infrastructure we are not able to handle on-premise and must migrate toward cloud providers. For instance, with CSAW'25 we are dealing with AWS EKS and >6k participants :grimacing: 
With the current stack, we are using the AWS LoadBalancer Controller from the Kubernetes SIG-AWS. It creates NLB/ALB as we need, and even if it is quite long to create the LoadBalancers in EC2, it ends up working fine after a few dozen of seconds.

## :globe_with_meridians: LoadBalancer

The problem with the current state of Chall-Manager SDK lays in its requirement for the Service to set a type `LoadBalancer`.
The proposal here is quite simple, and is motivated by the Kubernetes documentation: define type `LoadBalancer`, it will create a `NodePort`. Then, using the technology of our choice (e.g. the AWS LoadBalancer Controller) we can either use it or not, and use the External IP to give access to the challenge.

## :memo: Annotations

Still motivated by the same context of CSAW'25, but a few steps back to abstract things out...
Depending on your technical choices you might need to set annotations on the resources that exposes your containers (i.e. the `Service` if `exposeType=NodePort` or `exposeType=LoadBalancer`, the `Ingress` if `exposeType=Ingress`).

For instance, the following needs to be applied to a service for a NLB to be created by the AWS LoadBalancer Controller.
```yaml
apiVersion: v1
kind: Service
metadata:
  annotations:
    service.beta.kubernetes.io/aws-load-balancer-type: "external"
    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "HTTP"
    service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "traffic-port"
    service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "/"
# ...
```

One core idea of Chall-Manager SDK is to provide features to end users, but also abstract the complexity of figuring things out: you cannot focus on management, cybersecurity, dev, ops, ...
That way, I suggest to define annotations to pass to the exposing resource per port/protocol, and let the SDK deal with it, i.e. pass it to the actual resource that exposes the container on port/protocol.
This goes after a review of #886, which showed me there was support for both ingress annotations (all the same) and service annotations (specific per port/protocol), which is uneven + complex to understand by a non-specialist.

**TL;DR:**
- remove `IngressAnnotations`
- add `container(s)[].Ports[].Annotations`, passed to the exposing resource (Service or Ingress) depending on the `ExposeType`

---

For review, I'll be available tonight to explain it further :wink:

I'll make another PR to update the examples once we publish an update (minor).