### PR TITLE
Move OCI scenarios into cache

### DIFF
--- a/api/v1/challenge/update.go
+++ b/api/v1/challenge/update.go
@@ -444,15 +444,8 @@ func (store *Store) UpdateChallenge(ctx context.Context, req *UpdateChallengeReq
 		return nil, merr
 	}
 
-	// Tend to transactional operation, try to delete whatever happened
-	if oldDir != nil {
-		if err := os.RemoveAll(*oldDir); err != nil {
-			err := &errs.ErrInternal{Sub: err}
-			logger.Error(ctx, "removing challenge old directory",
-				zap.Error(err),
-			)
-		}
-	}
+	// Don't delete old directory, i.e. the previous scenario, as it could be reused
+	// by other challenges.
 
 	if err := fschall.Save(); err != nil {
 		err := &errs.ErrInternal{Sub: err}

--- a/go.work.sum
+++ b/go.work.sum
@@ -763,8 +763,6 @@ github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25Kn
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/go-restful/v3 v3.10.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
-github.com/emicklei/go-restful/v3 v3.12.2 h1:DhwDP0vY3k8ZzE0RunuJy8GhNpPL6zqLkDf9B/a0/xU=
-github.com/emicklei/go-restful/v3 v3.12.2/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.7/go.mod h1:cwu0lG7PUMfa9snN8LXBig5ynNVH9qI8YYLbd1fK2po=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20201210154907-fd9021fe5dad/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
 github.com/envoyproxy/go-control-plane v0.9.9-0.20210217033140-668b12f5399d/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
@@ -958,6 +956,7 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.24.0/go.mod h1:qztMSjm835F2bXf+5HKA
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.25.1/go.mod h1:RBRO7fro65R6tjKzYgLAFo0t1QEXY1Dp+i/bvpRiqiQ=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.1/go.mod h1:tIxuGz/9mpox++sgp9fJjHO0+q1X9/UOWd798aAm22M=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3/go.mod h1:ndYquD05frm2vACXE1nsccT4oJzjhw2arTS2cpUD1PI=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
 github.com/hanwen/go-fuse/v2 v2.5.0/go.mod h1:xKwi1cF7nXAOBCXujD5ie0ZKsxc8GGSA1rlMJc+8IJs=
 github.com/hashicorp/consul/api v1.25.1/go.mod h1:iiLVwR/htV7mas/sy0O+XSuEnrdBUUydemjxcUrAt4g=
@@ -1287,6 +1286,7 @@ github.com/stefanberger/go-pkcs11uri v0.0.0-20230803200340-78284954bff6/go.mod h
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stoewer/go-strcase v1.3.0/go.mod h1:fAH5hQ5pehh+j3nZfvwdk2RgEgQjAoM8wodgtPmh1xo=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/stretchr/testify v1.9.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
@@ -1320,6 +1320,7 @@ github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV
 github.com/xdg-go/pbkdf2 v1.0.0/go.mod h1:jrpuAogTd400dnrH08LKmI/xc1MbPOebTwRqcT5RDeI=
 github.com/xdg-go/scram v1.1.2/go.mod h1:RT/sEzTbU5y00aCK8UOx6R7YryM0iF1N2MOmC3kKLN4=
 github.com/xdg-go/stringprep v1.0.4/go.mod h1:mPGuuIYwz7CmR2bT9j4GbQqutWS1zV24gijq1dTyGkM=
+github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1 h1:gEOO8jv9F4OT7lGCjxCBTO/36wtF6j2nSip77qHd4x4=
 github.com/xrash/smetrics v0.0.0-20240521201337-686a1a2994c1/go.mod h1:Ohn+xnUBiLI6FVj/9LpzZWtj1/D6lUovWYBkxHVV3aM=
 github.com/yashtewari/glob-intersection v0.1.0/go.mod h1:LK7pIC3piUjovexikBbJ26Yml7g8xa5bsjfx2v1fwok=
@@ -1498,6 +1499,7 @@ golang.org/x/mod v0.15.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.18.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.19.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
+golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.23.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.25.0/go.mod h1:IXM97Txy2VM4PJ3gI61r1YEk/gAj6zAHN3AdZt6S9Ww=
 golang.org/x/net v0.0.0-20180811021610-c39426892332/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1899,7 +1901,9 @@ google.golang.org/genproto/googleapis/api v0.0.0-20250519155744-55703ea1f237/go.
 google.golang.org/genproto/googleapis/api v0.0.0-20250528174236-200df99c418a/go.mod h1:a77HrdMjoeKbnd2jmgcWdaS++ZLZAEq3orIOAEIKiVw=
 google.golang.org/genproto/googleapis/api v0.0.0-20250603155806-513f23925822/go.mod h1:h3c4v36UTKzUiuaOKQ6gr3S+0hovBtUrXzTG/i3+XEc=
 google.golang.org/genproto/googleapis/api v0.0.0-20250707201910-8d1bb00bc6a7/go.mod h1:kXqgZtrWaf6qS3jZOCnCH7WYfrvFjkC51bM8fz3RsCA=
+google.golang.org/genproto/googleapis/api v0.0.0-20250728155136-f173205681a0/go.mod h1:8ytArBbtOy2xfht+y2fqKd5DRDJRUQhqbyEnQ4bDChs=
 google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c/go.mod h1:ea2MjsO70ssTfCjiwHgI0ZFqcw45Ksuk2ckf9G468GA=
+google.golang.org/genproto/googleapis/api v0.0.0-20250825161204-c5933d9347a5/go.mod h1:j3QtIyytwqGr1JUDtYXwtMXWPKsEa5LtzIFN1Wn5WvE=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20231030173426-d783a09b4405/go.mod h1:GRUCuLdzVqZte8+Dl/D4N25yLzcGqqWaYkeVOwulFqw=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20231212172506-995d672761c0/go.mod h1:guYXGPwC6jwxgWKW5Y405fKWOFNwlvUlUnzyp9i0uqo=
 google.golang.org/genproto/googleapis/bytestream v0.0.0-20240125205218-1f4bbc51befe/go.mod h1:SCz6T5xjNXM4QFPRwxHcfChp7V+9DcXR3ay2TkHR8Tg=
@@ -2012,6 +2016,7 @@ google.golang.org/grpc v1.71.1/go.mod h1:H0GRtasmQOh9LkFoCPDu3ZrwUtD1YGE+b2vYBYd
 google.golang.org/grpc v1.72.1/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/grpc v1.72.2/go.mod h1:wH5Aktxcg25y1I3w7H69nHfXdOG3UiadoBtjh3izSDM=
 google.golang.org/grpc v1.73.0/go.mod h1:50sbHOUqWoCQGI8V2HQLJM0B+LMlIUjNSZmow7EVBQc=
+google.golang.org/grpc v1.75.0/go.mod h1:JtPAzKiq4v1xcAB2hydNlWI2RnF85XXcV0mhKXr2ecQ=
 google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.1.0/go.mod h1:6Kw0yEErY5E/yWrBtf03jp27GLLJujG4z/JK95pnjjw=
 google.golang.org/grpc/examples v0.0.0-20230224211313-3775f633ce20/go.mod h1:Nr5H8+MlGWr5+xX/STzdoEqJrO+YteqFbMyCsrb6mH0=
 google.golang.org/grpc/gcp/observability v1.0.1/go.mod h1:yM0UcrYRMe/B+Nu0mDXeTJNDyIMJRJnzuxqnJMz7Ewk=
@@ -2036,6 +2041,7 @@ google.golang.org/protobuf v1.36.3/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojt
 google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.7/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
+google.golang.org/protobuf v1.36.8/go.mod h1:fuxRtAxBytpl4zzqUh6/eyUujkJdNiuEkXntxiD/uRU=
 gopkg.in/DataDog/dd-trace-go.v1 v1.27.1/go.mod h1:Sp1lku8WJMvNV0kjDI4Ni/T7J/U3BO5ct5kEaoVU8+I=
 gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/fsnotify.v1 v1.4.7 h1:xOHLXZwVvI9hhs+cLKq5+I5onOuwQLhQwiu63xxlHs4=
@@ -2062,8 +2068,6 @@ k8s.io/apimachinery v0.31.2/go.mod h1:rsPdaZJfTfLsNJSQzNHQvYoTmxhoOEofxtOsF3rtsM
 k8s.io/apiserver v0.26.2/go.mod h1:GHcozwXgXsPuOJ28EnQ/jXEM9QeG6HT22YxSNmpYNh8=
 k8s.io/client-go v0.26.2/go.mod h1:u5EjOuSyBa09yqqyY7m3abZeovO/7D/WehVVlZ2qcqU=
 k8s.io/client-go v0.28.6/go.mod h1:+nu0Yp21Oeo/cBCsprNVXB2BfJTV51lFfe5tXl2rUL8=
-k8s.io/client-go v0.34.0 h1:YoWv5r7bsBfb0Hs2jh8SOvFbKzzxyNo0nSb0zC19KZo=
-k8s.io/client-go v0.34.0/go.mod h1:ozgMnEKXkRjeMvBZdV1AijMHLTh3pbACPvK7zFR+QQY=
 k8s.io/component-base v0.26.2/go.mod h1:DxbuIe9M3IZPRxPIzhch2m1eT7uFrSBJUBuVCQEBivs=
 k8s.io/cri-api v0.27.1/go.mod h1:+Ts/AVYbIo04S86XbTD73UPp/DkTiYxtsFeOFEu32L0=
 k8s.io/gengo/v2 v2.0.0-20240826214909-a7b603a56eb7/go.mod h1:EJykeLsmFC60UQbYJezXkEsG2FLrt0GPNkU5iK5GWxU=

--- a/pkg/scenario/oci_test.go
+++ b/pkg/scenario/oci_test.go
@@ -1,0 +1,63 @@
+package scenario
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_F_OCI(t *testing.T) {
+	t.Parallel()
+
+	var tests = map[string]struct {
+		Ref          string
+		ExpectedName string
+		ExpectedDig  string
+		ExpectErr    bool
+	}{
+		"named": {
+			// For this case we use an image that will not be updated thus
+			// we guarantee that "latest" image has indeed this corresponding hash.
+			Ref:          "pandatix/license-lvl1",
+			ExpectedName: "pandatix/license-lvl1",
+			ExpectedDig:  "sha256:acaca41979983579c871d13d407f2167c7394605fc08f3f36eb7484f12dbaf62",
+		},
+		"named-tagged": {
+			Ref:          "ctferio/chall-manager:v0.1.0-rc0",
+			ExpectedName: "ctferio/chall-manager",
+			ExpectedDig:  "sha256:272a63ea0a75b63f6dc6e34bce0b8591c9fc15549a1298b3ee9e2685a38bff7e",
+		},
+		"invalid digest named-tagged": {
+			//nolint:lll
+			Ref:          "ctferio/chall-manager:v0.1.0-rc0@sha256:db05b77564502a2db3409d0970810b8586b74d8fa40d0f234ca4a087d06c28d2", // actually the digest of v0.3.2
+			ExpectedName: "ctferio/chall-manager",
+			ExpectedDig:  "sha256:db05b77564502a2db3409d0970810b8586b74d8fa40d0f234ca4a087d06c28d2",
+			ExpectErr:    false, // in this specific case, the canonical form prevails thus it is valid
+		},
+		"canonical": {
+			//nolint:lll
+			Ref:          "ctferio/chall-manager:v0.1.0-rc0@sha256:272a63ea0a75b63f6dc6e34bce0b8591c9fc15549a1298b3ee9e2685a38bff7e",
+			ExpectedName: "ctferio/chall-manager",
+			ExpectedDig:  "sha256:272a63ea0a75b63f6dc6e34bce0b8591c9fc15549a1298b3ee9e2685a38bff7e",
+		},
+		"registry named-taged": {
+			Ref:       "localhost:5000/ctferio/chall-manager:v0.1.0-rc0",
+			ExpectErr: true,
+		},
+	}
+
+	for testname, tt := range tests {
+		t.Run(testname, func(t *testing.T) {
+			name, dig, err := resolve(t.Context(), tt.Ref, false, "", "")
+
+			if tt.ExpectErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+
+				assert.Equal(t, tt.ExpectedName, name)
+				assert.Equal(t, tt.ExpectedDig, dig)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What is the problem/feature ?

Chall-Manager, before OCI support, was copying the scenario in its global directory leading to collocated scenarios and filesystem-based _DB_.

Nonetheless, what needs to be distributed among replicas is actually the filesystem-DB, not the scenario... thus it is bloating the duplicated data. Moreover, for shared scenarios (e.g. the [recipes](https://github.com/ctfer-io/recipes)), this data is duplicated. Finally, these scenarios are expected to be available to all replicas in a OCI registry, thus can be quickly pulled back whenever required.

These is clearly a replica we could **completly remove**.

## What contains this PR ?

This PR proposes the following layout:
- store the filesystem _DB_ in `/tmp/chall-manager` (actually I'll move it to `/etc/chall-manager` in an other PR, it makes no sense in `/tmp` as we should expect it to be deleted whenever required, which could be quite inconvenient in production...);
- store the scenarios in the cache directory under `$HOME/.cache/chall-manager`. A directory is created for each scenario digest (i.e. the `sha256:a0b1...c2d3`), motivated per the rationale that it should be random enough and reproducible throughout replicas so it does not end up impossible to debug in live.

TL;DR: move the scenarios out of the filesystem _DB_, and share them between challenges if required.

## What are the impacts ?

For `chall-manager@v0.5.3` (latest at the time of writing), here is the layout for the example `additional`.

```
$ tree /tmp/chall-manager/ --du -h
[ 34M]  /tmp/chall-manager/
└── [ 34M]  chall
    └── [ 34M]  c4ca4238a0b923820dcc509a6f75849b
        ├── [ 34M]  88c000024ecf54c62ce4fe34ff9879cd
        │   ├── [4.6K]  go.mod
        │   ├── [ 28K]  go.sum
        │   ├── [ 34M]  main
        │   ├── [ 405]  main.go
        │   └── [ 162]  Pulumi.yaml
        ├── [ 187]  info.json
        └── [4.0K]  instance

 134M used in 5 directories, 6 files
```

With this PR, here are the layouts.

```
$ tree /tmp/chall-manager/ --du -h
[ 16K]  /tmp/chall-manager/
└── [ 12K]  chall
    └── [8.2K]  c4ca4238a0b923820dcc509a6f75849b
        ├── [ 208]  info.json
        └── [4.0K]  instance

  25K used in 4 directories, 1 file
```

```
$ tree $HOME/.cache/chall-manager/ --du -h
[ 34M]  $HOME/.cache/chall-manager/
└── [ 34M]  oci
    └── [ 34M]  sha256:896d3c7c64b9d682cb7381315cf70432f9d8e1953bf867edb176a781bd3b55f0
        ├── [4.6K]  go.mod
        ├── [ 28K]  go.sum
        ├── [ 34M]  main
        ├── [ 405]  main.go
        └── [ 162]  Pulumi.yaml

 101M used in 3 directories, 5 files
```

Globally, with a smaller filesystem arboresence, it also reduces the impact on disk for the cached scenarios.

For self-hosted it is cool, reduces load.
For cloud providers use cases (e.g. AWS with EFS) it could also reduce billing :money_with_wings: 