### PR TITLE
feat(#978): configure cache directory

### DIFF
--- a/cmd/chall-manager/main.go
+++ b/cmd/chall-manager/main.go
@@ -56,6 +56,15 @@ func main() {
 				Usage:       "Define the volume to read/write stack and states to. It should be sharded across replicas for HA.",
 			},
 			&cli.StringFlag{
+				Name:        "cache",
+				Sources:     cli.EnvVars("CACHE"),
+				Category:    "global",
+				Destination: &global.Conf.Cache,
+				Usage: "Override the cache directory to store OCI layouts. Default to $HOME/.cache/chall-manager. " +
+					"WARNING: do not touch if you are not sure of what you are doing !",
+				TakesFile: true, // a directory actually
+			},
+			&cli.StringFlag{
 				Name:     "log-level",
 				Sources:  cli.EnvVars("LOG_LEVEL"),
 				Category: "global",

--- a/global/cache.go
+++ b/global/cache.go
@@ -1,0 +1,29 @@
+package global
+
+import (
+	"os"
+	"path/filepath"
+)
+
+var (
+	cacheDir = filepath.Join(os.Getenv("HOME"), ".cache", "chall-manager")
+)
+
+// CacheDir returns the cache directory, either configured or defaulted
+// to $HOME/.cache/chall-manager.
+func CacheDir() string {
+	if Conf.Cache != "" {
+		return Conf.Cache
+	}
+
+	// guarantee that even if $HOME is "/root", "/home/someone", or nothing, it catches
+	// that it should be an absolute path to avoid interpretations.
+	// This has been manually tested, worked fine, but enables checking it works even if
+	// the Docker image changes in the future (e.g. minimization), or the Go behavior
+	// changes (which should not, but the check is not costful so let's do it).
+	if !filepath.IsAbs(cacheDir) {
+		panic("cache directory is not absolute")
+	}
+
+	return cacheDir
+}

--- a/global/config.go
+++ b/global/config.go
@@ -7,6 +7,7 @@ var (
 // Configuration holds the parameters that are shared across submodules.
 type Configuration struct {
 	Directory string
+	Cache     string
 	LogLevel  string
 
 	Otel struct {

--- a/pkg/scenario/oci.go
+++ b/pkg/scenario/oci.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/ctfer-io/chall-manager/global"
 	"github.com/distribution/reference"
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/crane"
@@ -23,21 +24,6 @@ import (
 const (
 	sha256 = "sha256"
 )
-
-var (
-	cacheDir = filepath.Join(os.Getenv("HOME"), ".cache", "chall-manager", "oci")
-)
-
-func init() {
-	// guarantee that even if $HOME is "/root", "/home/someone", or nothing, it catches
-	// that it should be an absolute path to avoid interpretations.
-	// This has been manually tested, worked fine, but enables checking it works even if
-	// the Docker image changes in the future (e.g. minimization), or the Go behavior
-	// changes (which should not, but the check is not costful so let's do it).
-	if !filepath.IsAbs(cacheDir) {
-		panic("cache directory is not absolute")
-	}
-}
 
 // NewORASClient creates an ORAS client, possibly authenticated.
 func NewORASClient(ref string, username, password string) (*auth.Client, error) {
@@ -162,7 +148,7 @@ func DecodeOCI(
 	}
 
 	// Get the corresponding directory
-	dir := filepath.Join(cacheDir, dig)
+	dir := filepath.Join(global.CacheDir(), "oci", dig)
 	fs, err := file.New(dir)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Resolves #978

I add the `--cache` CLI flag and `CACHE` environment variable to configure the cache directory.
Is it now a global thing, used per the `pkg/scenario` under the `oci` sub-directory to be future-proof (if we ever want to cache other things it will be possible without conflicts with the current OCI stuff).

I don't consider adding this parametrisable per the `deploy` stack as this should not be a problem on Kubernetes. Assumption is based upon rationale that a local volume should not be a problem. I might come back on this idea later, e.g., when dealing with #977

Let me know if you consider this last point a limitation of the PR :wink: