### PR TITLE
fix(ci): fix buf parameters according to bufbuild/buf#4157

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,7 @@ jobs:
       - uses: bufbuild/buf-action@8f4a1456a0ab6a1eb80ba68e53832e6fcfacc16c # v1.3.0
         with:
           token: ${{ secrets.BUF_TOKEN }}
+          push_disable_create: true # repository already created - see bufbuild/buf#4157
 
   goreleaser:
     outputs:


### PR DESCRIPTION
Resolves the issue we encountered with release v0.6.1 and bufbuild not working. BTW it does not invalidate the release, only the `buf` job, which is not _important_ as we did not touch the API schema.