### PR TITLE
ci(stalebot): configure stalebot for triage inactivity handling

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,0 +1,29 @@
+name: Mark and close stale triage issues
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+permissions:
+  issues: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@997185467fa4f803885201cee163a9f38240193d # v10.1.1
+        with:
+          # Only process issues with "triage" label
+          only-issue-labels: triage
+
+          # Disable PR handling entirely
+          days-before-pr-stale: -1
+          days-before-pr-close: -1
+
+          # Messages
+          stale-issue-message: >
+            This issue has been marked as stale due to 60 days of inactivity.
+            It will be closed in 7 days if no further activity occurs.
+          close-issue-message: >
+            Closing this issue due to prolonged inactivity.


### PR DESCRIPTION
This PR adds the [stalebot](https://github.com/actions/stale). It is configured to process issues with the `triage` label with no activity after 60 days.

It gives us 2 months to triage an issue opened for a bug thus remove triage status. We don't remove it if we cannot reproduce the described problem(s), meaning it is automatically closed if the issue author (or a contributor) does not provide more info.
