### PR TITLE
fix(deploy): remove duplicated configuration after Pulumi regression fix

### DIFF
--- a/deploy/integration/cluster_test.go
+++ b/deploy/integration/cluster_test.go
@@ -36,10 +36,6 @@ func Test_I_Cluster(t *testing.T) {
 			"replicas":         "1",             // no need to replicate, we test proper deployments
 			"etcd-replicas":    "1",             // no need to replicate, we test proper deployment
 			"expose":           "true",          // make API externally reachable
-			// Following config values are defined, seems like due to a bug in Pulumi loading config
-			"etcd.replicas": "1",
-			"oci.insecure":  "true",
-			"otel.insecure": "true",
 		},
 		Secrets: map[string]string{
 			"kubeconfig": "",

--- a/deploy/integration/examples_test.go
+++ b/deploy/integration/examples_test.go
@@ -54,10 +54,6 @@ func Test_I_Examples(t *testing.T) {
 			"oci-insecure":     "true",          // don't mind HTTPS on the CI registry
 			"pvc-access-mode":  "ReadWriteOnce", // don't need to scale (+ not possible with kind in CI)
 			"expose":           "true",          // make API externally reachable
-			// Following config values are defined, seems like due to a bug in Pulumi loading config
-			"etcd.replicas": "1",
-			"oci.insecure":  "true",
-			"otel.insecure": "true",
 		},
 		Secrets: map[string]string{
 			"kubeconfig": "",

--- a/deploy/integration/monitoring_test.go
+++ b/deploy/integration/monitoring_test.go
@@ -60,10 +60,6 @@ func Test_I_Monitoring(t *testing.T) {
 			"registry":         os.Getenv("REGISTRY"),
 			"tag":              os.Getenv("TAG"),
 			"romeo-claim-name": os.Getenv("ROMEO_CLAIM_NAME"),
-			// Following config values are defined, seems like due to a bug in Pulumi loading config
-			"etcd.replicas": "0",
-			"oci.insecure":  "true",
-			"otel.insecure": "true",
 		},
 		Secrets: map[string]string{
 			"kubeconfig": "",

--- a/deploy/integration/pooler_test.go
+++ b/deploy/integration/pooler_test.go
@@ -43,10 +43,6 @@ func Test_I_UpdatePooler(t *testing.T) {
 			"oci-insecure":     "true",          // don't mind HTTPS on the CI registry
 			"pvc-access-mode":  "ReadWriteOnce", // don't need to scale (+ not possible with kind in CI)
 			"expose":           "true",          // make API externally reachable
-			// Following config values are defined, seems like due to a bug in Pulumi loading config
-			"etcd.replicas": "1",
-			"oci.insecure":  "true",
-			"otel.insecure": "true",
 		},
 		Secrets: map[string]string{
 			"kubeconfig": "",

--- a/deploy/integration/standard_test.go
+++ b/deploy/integration/standard_test.go
@@ -44,10 +44,6 @@ func Test_I_Standard(t *testing.T) {
 			"expose":           "true",          // make API externally reachable
 			"janitor-mode":     "ticker",
 			"janitor-ticker":   "5s",
-			// Following config values are defined, seems like due to a bug in Pulumi loading config
-			"etcd.replicas": "1",
-			"oci.insecure":  "true",
-			"otel.insecure": "true",
 		},
 		Secrets: map[string]string{
 			"kubeconfig": "",

--- a/deploy/integration/update_challenge_test.go
+++ b/deploy/integration/update_challenge_test.go
@@ -49,10 +49,6 @@ func Test_I_Update(t *testing.T) {
 			"oci-insecure":     "true",          // don't mind HTTPS on the CI registry
 			"pvc-access-mode":  "ReadWriteOnce", // don't need to scale (+ not possible with kind in CI)
 			"expose":           "true",          // make API externally reachable
-			// Following config values are defined, seems like due to a bug in Pulumi loading config
-			"etcd.replicas": "1",
-			"oci.insecure":  "true",
-			"otel.insecure": "true",
 		},
 		Secrets: map[string]string{
 			"kubeconfig": "",


### PR DESCRIPTION
Echoes #1079 

This PR removes a temporary patch I applied in #1076 to fix a Pulumi regression.
