### PR TITLE
impr(api): add automatic recovery if API panics on a call

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/recovery"
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"github.com/improbable-eng/grpc-web/go/grpcweb"
 	"github.com/soheilhy/cmux"
@@ -118,6 +119,8 @@ func (s *Server) newGRPCServer() *grpc.Server {
 	// Create the gRPC server
 	opts := []grpc.ServerOption{
 		grpc.StatsHandler(otelgrpc.NewServerHandler()),
+		grpc.UnaryInterceptor(recovery.UnaryServerInterceptor()),
+		grpc.StreamInterceptor(recovery.StreamServerInterceptor()),
 	}
 	grpcServer := grpc.NewServer(opts...)
 


### PR DESCRIPTION
This PR adds a simple safety measure to avoid availability loss in case an API call make CM panics.

Currently, if something panics on an API call the whole service stops. In case the hosting platform does not recover (e.g. Kubernetes does so, not Docker Compose), the service becomes unavailable. This might be used by attackers to DoS CTF infrastructures.