### PR TITLE
fix: revert buf config after #1078

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,6 @@ jobs:
       - uses: bufbuild/buf-action@8f4a1456a0ab6a1eb80ba68e53832e6fcfacc16c # v1.3.0
         with:
           token: ${{ secrets.BUF_TOKEN }}
-          push_disable_create: true # repository already created - see bufbuild/buf#4157
 
   goreleaser:
     outputs:


### PR DESCRIPTION
Reverts #1078 as it has been fixed a while ago, we should no longer need this.