### PR TITLE
ci: only check for diffs in source code and generated artifacts (at dev time)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Check if Go code has changed
         run: |
-          if git diff --exit-code; then
+          if git diff --exit-code -- '*.go' '*.proto' '*.yaml' '*.json' ':!*.sum'; then
             echo "Generated Go code has not changed."
           else
             echo "Generated Go code has changed. Please make sure to commit the changes."


### PR DESCRIPTION
Let's only check the diff for files we actually have control over.
Right now, when a Go dependency is updated there is a high probability that it ends up modifying the `go.work.sum` file. If it is not commited, it is not a big deal (I think ?) so this filter removes it. By the way, borrowed from another project where it works fine :wink: